### PR TITLE
Wrapper lens instances

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -35,6 +35,7 @@ default-extensions:
 - GADTs
 - DataKinds
 - PolyKinds
+- RankNTypes
 
 
 dependencies:

--- a/package.yaml
+++ b/package.yaml
@@ -31,6 +31,10 @@ default-extensions:
 - RecordWildCards
 - FlexibleContexts
 - DeriveGeneric
+- TypeFamilies
+- GADTs
+- DataKinds
+- PolyKinds
 
 
 dependencies:

--- a/src/Network/ABCI/Types/Messages/.#Response.hs
+++ b/src/Network/ABCI/Types/Messages/.#Response.hs
@@ -1,0 +1,1 @@
+martyall@Martins-MacBook-Pro.local.73972

--- a/src/Network/ABCI/Types/Messages/.#Response.hs
+++ b/src/Network/ABCI/Types/Messages/.#Response.hs
@@ -1,1 +1,0 @@
-martyall@Martins-MacBook-Pro.local.73972

--- a/src/Network/ABCI/Types/Messages/FieldTypes.hs
+++ b/src/Network/ABCI/Types/Messages/FieldTypes.hs
@@ -30,7 +30,8 @@ import           Data.Time.Clock
                                                                                    picosecondsToDiffTime)
 import           Data.Word
                                                                                    (Word64)
-import GHC.Generics (Generic)
+import           GHC.Generics
+                                                                                   (Generic)
 import qualified Proto.Types                                                      as PT
 import qualified Proto.Types_Fields                                               as PT
 import qualified Proto.Vendored.Google.Protobuf.Timestamp                         as T

--- a/src/Network/ABCI/Types/Messages/FieldTypes.hs
+++ b/src/Network/ABCI/Types/Messages/FieldTypes.hs
@@ -278,7 +278,7 @@ version = iso t f
     t Version{..} =
       defMessage & PT.block .~ versionBlock
                  & PT.app .~ versionApp
-    f version =
+    f a =
       Version
         { versionBlock = a ^. PT.block
         , versionApp = a ^. PT.app
@@ -376,13 +376,13 @@ data Evidence = Evidence
 evidence :: Iso' Evidence PT.Evidence
 evidence = iso t f
   where
-    to Evidence{..} =
+    t Evidence{..} =
       defMessage & PT.type' .~ evidenceType
                  & PT.maybe'validator .~ evidenceValidator ^? _Just . validator
                  & PT.height .~ evidenceHeight
                  & PT.maybe'time .~ evidenceTime ^? _Just . timestamp
                  & PT.totalVotingPower .~ evidenceTotalVotingPower
-    from a =
+    f a =
       Evidence
         { evidenceType = a ^. PT.type'
         , evidenceValidator = a ^? PT.maybe'validator . _Just . Lens.from validator
@@ -421,7 +421,7 @@ data Proof = Proof
 proof :: Iso' Proof MT.Proof
 proof = iso t f
   where
-    to Proof{..} =
+    t Proof{..} =
       defMessage
         & MT.ops .~ proofOps ^.. traverse . proofOp
     f a =
@@ -442,12 +442,12 @@ data ProofOp = ProofOp
 proofOp :: Iso' ProofOp MT.ProofOp
 proofOp = iso t f
   where
-    to ProofOp{..} =
+    t ProofOp{..} =
       defMessage
         & MT.type' .~ proofOpType
         & MT.key .~ proofOpKey
         & MT.data' .~ proofOpData
-    from a =
+    f a =
       ProofOp
         { proofOpType = a ^. MT.type'
         , proofOpKey = a ^. MT.key

--- a/src/Network/ABCI/Types/Messages/FieldTypes.hs
+++ b/src/Network/ABCI/Types/Messages/FieldTypes.hs
@@ -5,6 +5,7 @@ import           Control.Lens
                                                                                    iso,
                                                                                    mapped,
                                                                                    over,
+                                                                                   from,
                                                                                    traverse,
                                                                                    view,
                                                                                    (%~),
@@ -14,7 +15,6 @@ import           Control.Lens
                                                                                    (^..),
                                                                                    (^?),
                                                                                    _Just)
-import qualified Control.Lens                                                     as Lens
 import           Data.ByteString
                                                                                    (ByteString)
 import           Data.Int
@@ -127,9 +127,9 @@ consensusParams = iso t f
                  & PT.maybe'validator .~ consensusParamsValidator ^? _Just . validatorParams
     f a =
       ConsensusParams
-        { consensusParamsBlockSize = a ^? PT.maybe'blockSize . _Just . Lens.from blockSizeParams
-        , consensusParamsEvidence =  a ^? PT.maybe'evidence . _Just . Lens.from evidenceParams
-        , consensusParamsValidator =  a ^? PT.maybe'validator . _Just . Lens.from validatorParams
+        { consensusParamsBlockSize = a ^? PT.maybe'blockSize . _Just . from blockSizeParams
+        , consensusParamsEvidence =  a ^? PT.maybe'evidence . _Just . from evidenceParams
+        , consensusParamsValidator =  a ^? PT.maybe'validator . _Just . from validatorParams
         }
 
 data PubKey = PubKey
@@ -166,7 +166,7 @@ validatorUpdate = iso t f
                  & PT.power .~ validatorUpdatePower
     f a =
       ValidatorUpdate
-        { validatorUpdatePubKey = a ^? PT.maybe'pubKey . _Just . Lens.from pubKey
+        { validatorUpdatePubKey = a ^? PT.maybe'pubKey . _Just . from pubKey
         , validatorUpdatePower = a ^. PT.power
         }
 
@@ -204,7 +204,7 @@ voteInfo = iso t f
                  & PT.signedLastBlock .~ voteInfoSignedLastBlock
     f voteInfo =
       VoteInfo
-        { voteInfoValidator = voteInfo ^? PT.maybe'validator . _Just . Lens.from validator
+        { voteInfoValidator = voteInfo ^? PT.maybe'validator . _Just . from validator
         , voteInfoSignedLastBlock = voteInfo ^. PT.signedLastBlock
         }
 
@@ -225,7 +225,7 @@ lastCommitInfo = iso t f
     f a =
       LastCommitInfo
         { lastCommitInfoRound = a ^. PT.round
-        , lastCommitInfoVotes = a ^.. PT.votes . traverse . Lens.from voteInfo
+        , lastCommitInfoVotes = a ^.. PT.votes . traverse . from voteInfo
         }
 
 data PartSetHeader = PartSetHeader
@@ -262,7 +262,7 @@ blockID = iso t f
     f a =
       BlockID
         { blockIDHash = a ^. PT.hash
-        , blockIDPartsHeader = a ^? PT.maybe'partsHeader . _Just . Lens.from partSetHeader
+        , blockIDPartsHeader = a ^? PT.maybe'partsHeader . _Just . from partSetHeader
         }
 
 data Version = Version
@@ -342,13 +342,13 @@ header = iso t f
                  & PT.proposerAddress .~ headerProposerAddress
     f a =
       Header
-        { headerVersion = a ^? PT.maybe'version . _Just . Lens.from version
+        { headerVersion = a ^? PT.maybe'version . _Just . from version
         , headerChainId = a ^. PT.chainId
         , headerHeight = a ^. PT.height
-        , headerTime = a ^? PT.maybe'time . _Just . Lens.from timestamp
+        , headerTime = a ^? PT.maybe'time . _Just . from timestamp
         , headerNumTxs = a ^. PT.numTxs
         , headerTotalTxs = a ^. PT.totalTxs
-        , headerLastBlockId = a ^. PT.lastBlockId. Lens.from blockID
+        , headerLastBlockId = a ^. PT.lastBlockId. from blockID
         , headerLastCommitHash = a ^. PT.lastCommitHash
         , headerDataHash = a ^. PT.dataHash
         , headerValidatorsHash = a ^. PT.validatorsHash
@@ -385,9 +385,9 @@ evidence = iso t f
     f a =
       Evidence
         { evidenceType = a ^. PT.type'
-        , evidenceValidator = a ^? PT.maybe'validator . _Just . Lens.from validator
+        , evidenceValidator = a ^? PT.maybe'validator . _Just . from validator
         , evidenceHeight = a ^. PT.height
-        , evidenceTime = a ^? PT.maybe'time . _Just . Lens.from timestamp
+        , evidenceTime = a ^? PT.maybe'time . _Just . from timestamp
         , evidenceTotalVotingPower = a ^. PT.totalVotingPower
         }
 
@@ -426,7 +426,7 @@ proof = iso t f
         & MT.ops .~ proofOps ^.. traverse . proofOp
     f a =
       Proof
-        { proofOps = a ^.. MT.ops . traverse . Lens.from proofOp
+        { proofOps = a ^.. MT.ops . traverse . from proofOp
         }
 
 

--- a/src/Network/ABCI/Types/Messages/FieldTypes.hs
+++ b/src/Network/ABCI/Types/Messages/FieldTypes.hs
@@ -45,315 +45,351 @@ data Timestamp =
   Timestamp DiffTime deriving (Eq, Show, Generic)
 
 timestamp :: Iso' Timestamp T.Timestamp
-timestamp = iso to from
+timestamp = iso t f
   where
     tenToTwelth = 1000000000000
     tenToThird = 1000
-    to (Timestamp t) =
+    t (Timestamp t) =
       let ps = diffTimeToPicoseconds t
           s = ps `div` tenToTwelth
           ns = (ps - s * tenToTwelth) `div` tenToThird
       in defMessage & T.seconds .~ fromInteger s
                     & T.nanos .~ fromInteger ns
-    from ts =
+    f ts =
       let ps1 = toInteger (ts ^. T.seconds) * tenToTwelth
           ps2 = toInteger (ts ^. T.nanos) * tenToThird
       in Timestamp . picosecondsToDiffTime $ ps1 + ps2
 
-data BlockSizeParams =
-  BlockSizeParams { blockSizeParamsMaxBytes :: Int64
-                  -- ^ Max size of a block, in bytes.
-                  , blockSizeParamsMaxGas   :: Int64
-                  -- ^ Max sum of GasWanted in a proposed block.
-                  } deriving (Eq, Show, Generic)
+data BlockSizeParams = BlockSizeParams
+  { blockSizeParamsMaxBytes :: Int64
+  -- ^ Max size of a block, in bytes.
+  , blockSizeParamsMaxGas   :: Int64
+  -- ^ Max sum of GasWanted in a proposed block.
+  } deriving (Eq, Show, Generic)
 
 blockSizeParams :: Iso' BlockSizeParams PT.BlockSizeParams
-blockSizeParams = iso to from
+blockSizeParams = iso t f
   where
-    to BlockSizeParams{..} = defMessage & PT.maxBytes .~ blockSizeParamsMaxBytes
-                                        & PT.maxGas .~ blockSizeParamsMaxGas
-    from bsParams = BlockSizeParams { blockSizeParamsMaxBytes = bsParams ^. PT.maxBytes
-                                    , blockSizeParamsMaxGas = bsParams ^. PT.maxGas
-                                    }
+    t BlockSizeParams{..} =
+      defMessage & PT.maxBytes .~ blockSizeParamsMaxBytes
+                 & PT.maxGas .~ blockSizeParamsMaxGas
+    f a =
+      BlockSizeParams
+        { blockSizeParamsMaxBytes = a ^. PT.maxBytes
+        , blockSizeParamsMaxGas = a ^. PT.maxGas
+        }
 
-data EvidenceParams =
-  EvidenceParams { evidenceParamsMaxAge :: Int64
-                 -- ^ Max age of evidence, in blocks.
-                 } deriving (Eq, Show, Generic)
+data EvidenceParams = EvidenceParams
+  { evidenceParamsMaxAge :: Int64
+  -- ^ Max age of evidence, in blocks.
+  } deriving (Eq, Show, Generic)
 
 evidenceParams :: Iso' EvidenceParams PT.EvidenceParams
-evidenceParams = iso to from
+evidenceParams = iso t f
   where
-    to EvidenceParams{..} = defMessage & PT.maxAge .~ evidenceParamsMaxAge
-    from eParams = EvidenceParams { evidenceParamsMaxAge = eParams ^. PT.maxAge
-                                  }
+    t EvidenceParams{..} =
+      defMessage & PT.maxAge .~ evidenceParamsMaxAge
+    f a =
+      EvidenceParams
+        { evidenceParamsMaxAge = a ^. PT.maxAge
+        }
 
-data ValidatorParams =
-  ValidatorParams { validatorParamsPubKeyTypes :: [Text]
-                  -- ^ List of accepted pubkey types
-                  } deriving (Eq, Show, Generic)
+data ValidatorParams = ValidatorParams
+  { validatorParamsPubKeyTypes :: [Text]
+  -- ^ List of accepted pubkey types
+  } deriving (Eq, Show, Generic)
 
 validatorParams :: Iso' ValidatorParams PT.ValidatorParams
-validatorParams = iso to from
+validatorParams = iso t f
   where
-    to ValidatorParams{..} = defMessage & PT.pubKeyTypes .~ validatorParamsPubKeyTypes
-    from vParams = ValidatorParams { validatorParamsPubKeyTypes = vParams ^. PT.pubKeyTypes
-                                   }
+    t ValidatorParams{..} =
+      defMessage & PT.pubKeyTypes .~ validatorParamsPubKeyTypes
+    f a =
+      ValidatorParams
+        { validatorParamsPubKeyTypes = a ^. PT.pubKeyTypes
+        }
 
-data ConsensusParams =
-  ConsensusParams { consensusParamsBlockSize :: Maybe BlockSizeParams
-                  --  ^ Parameters limiting the size of a block and time between consecutive blocks.
-                  , consensusParamsEvidence  :: Maybe EvidenceParams
-                  -- ^ Parameters limiting the validity of evidence of byzantine behaviour.
-                  , consensusParamsValidator :: Maybe ValidatorParams
-                  -- ^ Parameters limitng the types of pubkeys validators can use.
-                  } deriving (Eq, Show, Generic)
+data ConsensusParams = ConsensusParams
+  { consensusParamsBlockSize :: Maybe BlockSizeParams
+  --  ^ Parameters limiting the size of a block and time between consecutive blocks.
+  , consensusParamsEvidence  :: Maybe EvidenceParams
+  -- ^ Parameters limiting the validity of evidence of byzantine behaviour.
+  , consensusParamsValidator :: Maybe ValidatorParams
+  -- ^ Parameters limitng the types of pubkeys validators can use.
+  } deriving (Eq, Show, Generic)
 
 consensusParams :: Iso' ConsensusParams PT.ConsensusParams
-consensusParams = iso to from
+consensusParams = iso t f
   where
-    to ConsensusParams{..} = defMessage & PT.maybe'blockSize .~ consensusParamsBlockSize ^? _Just . blockSizeParams
-                                        & PT.maybe'evidence .~ consensusParamsEvidence ^? _Just . evidenceParams
-                                        & PT.maybe'validator .~ consensusParamsValidator ^? _Just . validatorParams
-    from cParams = ConsensusParams { consensusParamsBlockSize = cParams ^? PT.maybe'blockSize . _Just . Lens.from blockSizeParams
-                                   , consensusParamsEvidence =  cParams ^? PT.maybe'evidence . _Just . Lens.from evidenceParams
-                                   , consensusParamsValidator =  cParams ^? PT.maybe'validator . _Just . Lens.from validatorParams
-                                   }
+    t ConsensusParams{..} =
+      defMessage & PT.maybe'blockSize .~ consensusParamsBlockSize ^? _Just . blockSizeParams
+                 & PT.maybe'evidence .~ consensusParamsEvidence ^? _Just . evidenceParams
+                 & PT.maybe'validator .~ consensusParamsValidator ^? _Just . validatorParams
+    f a =
+      ConsensusParams
+        { consensusParamsBlockSize = a ^? PT.maybe'blockSize . _Just . Lens.from blockSizeParams
+        , consensusParamsEvidence =  a ^? PT.maybe'evidence . _Just . Lens.from evidenceParams
+        , consensusParamsValidator =  a ^? PT.maybe'validator . _Just . Lens.from validatorParams
+        }
 
-data PubKey =
-  PubKey { pubKeyType :: Text
-         -- ^ Type of the public key.
-         , pubKeyData :: ByteString
-         -- ^ Public key data.
-         } deriving (Eq, Show, Generic)
+data PubKey = PubKey
+  { pubKeyType :: Text
+  -- ^ Type of the public key.
+  , pubKeyData :: ByteString
+  -- ^ Public key data.
+  } deriving (Eq, Show, Generic)
 
 pubKey :: Iso' PubKey PT.PubKey
-pubKey = iso to from
+pubKey = iso t f
   where
-    to PubKey{..} = defMessage & PT.type' .~ pubKeyType
+    t PubKey{..} = defMessage & PT.type' .~ pubKeyType
                                & PT.data' .~ pubKeyData
 
-    from pk = PubKey { pubKeyType = pk ^. PT.type'
-                     , pubKeyData = pk ^. PT.data'
-                     }
+    f a =
+      PubKey
+        { pubKeyType = a ^. PT.type'
+        , pubKeyData = a ^. PT.data'
+        }
 
-data ValidatorUpdate =
-  ValidatorUpdate { validatorUpdatePubKey :: Maybe PubKey
-                  -- ^ Public key of the validator
-                  , validatorUpdatePower  :: Int64
-                  -- ^ Voting power of the validator
-                  } deriving (Eq, Show, Generic)
+data ValidatorUpdate = ValidatorUpdate
+  { validatorUpdatePubKey :: Maybe PubKey
+  -- ^ Public key of the validator
+  , validatorUpdatePower  :: Int64
+  -- ^ Voting power of the validator
+  } deriving (Eq, Show, Generic)
 
 validatorUpdate :: Iso' ValidatorUpdate PT.ValidatorUpdate
-validatorUpdate = iso to from
+validatorUpdate = iso t f
   where
-    to ValidatorUpdate{..} = defMessage & PT.maybe'pubKey .~ validatorUpdatePubKey ^? _Just . pubKey
-                                        & PT.power .~ validatorUpdatePower
-    from vu = ValidatorUpdate { validatorUpdatePubKey = vu ^? PT.maybe'pubKey . _Just . Lens.from pubKey
-                              , validatorUpdatePower = vu ^. PT.power
-                              }
+    t ValidatorUpdate{..} =
+      defMessage & PT.maybe'pubKey .~ validatorUpdatePubKey ^? _Just . pubKey
+                 & PT.power .~ validatorUpdatePower
+    f a =
+      ValidatorUpdate
+        { validatorUpdatePubKey = a ^? PT.maybe'pubKey . _Just . Lens.from pubKey
+        , validatorUpdatePower = a ^. PT.power
+        }
 
-data Validator =
-  Validator { validatorAddress :: ByteString
-            -- ^ Address of the validator (hash of the public key)
-            , validatorPower   :: Int64
-            -- ^ Voting power of the validator
-            } deriving (Eq, Show, Generic)
+data Validator = Validator
+  { validatorAddress :: ByteString
+  -- ^ Address of the validator (hash of the public key)
+  , validatorPower   :: Int64
+  -- ^ Voting power of the validator
+  } deriving (Eq, Show, Generic)
 
 validator :: Iso' Validator PT.Validator
-validator = iso to from
+validator = iso t f
   where
-    to Validator{..} = defMessage & PT.address .~ validatorAddress
-                                  & PT.power .~ validatorPower
-    from validator = Validator { validatorAddress = validator ^. PT.address
-                               , validatorPower = validator ^. PT.power
-                               }
+    t Validator{..} =
+      defMessage & PT.address .~ validatorAddress
+                 & PT.power .~ validatorPower
+    f a =
+      Validator
+        { validatorAddress = a ^. PT.address
+        , validatorPower = a ^. PT.power
+        }
 
-data VoteInfo =
-  VoteInfo { voteInfoValidator       :: Maybe Validator
-           -- ^ A validator
-           , voteInfoSignedLastBlock :: Bool
-           -- ^ Indicates whether or not the validator signed the last block
-           } deriving (Eq, Show, Generic)
+data VoteInfo = VoteInfo
+  { voteInfoValidator       :: Maybe Validator
+  -- ^ A validator
+  , voteInfoSignedLastBlock :: Bool
+  -- ^ Indicates whether or not the validator signed the last block
+  } deriving (Eq, Show, Generic)
 
 voteInfo :: Iso' VoteInfo PT.VoteInfo
-voteInfo = iso to from
+voteInfo = iso t f
   where
-    to VoteInfo{..} = defMessage & PT.maybe'validator .~ voteInfoValidator ^? _Just . validator
-                                 & PT.signedLastBlock .~ voteInfoSignedLastBlock
-    from voteInfo = VoteInfo { voteInfoValidator = voteInfo ^? PT.maybe'validator . _Just . Lens.from validator
-                             , voteInfoSignedLastBlock = voteInfo ^. PT.signedLastBlock
-                             }
+    t VoteInfo{..} =
+      defMessage & PT.maybe'validator .~ voteInfoValidator ^? _Just . validator
+                 & PT.signedLastBlock .~ voteInfoSignedLastBlock
+    f voteInfo =
+      VoteInfo
+        { voteInfoValidator = voteInfo ^? PT.maybe'validator . _Just . Lens.from validator
+        , voteInfoSignedLastBlock = voteInfo ^. PT.signedLastBlock
+        }
 
-data LastCommitInfo =
-  LastCommitInfo { lastCommitInfoRound :: Int32
-                 -- ^ Commit round.
-                 , lastCommitInfoVotes :: [VoteInfo]
-                 -- ^ List of validators addresses in the last validator set with their voting
-                 -- power and whether or not they signed a vote.
-                 } deriving (Eq, Show, Generic)
+data LastCommitInfo = LastCommitInfo
+  { lastCommitInfoRound :: Int32
+  -- ^ Commit round.
+  , lastCommitInfoVotes :: [VoteInfo]
+  -- ^ List of validators addresses in the last validator set with their voting
+  -- power and whether or not they signed a vote.
+  } deriving (Eq, Show, Generic)
 
 lastCommitInfo :: Iso' LastCommitInfo PT.LastCommitInfo
-lastCommitInfo = iso to from
+lastCommitInfo = iso t f
   where
-    to LastCommitInfo{..} = defMessage & PT.round .~ lastCommitInfoRound
-                                       & PT.votes .~ lastCommitInfoVotes ^.. traverse . voteInfo
-    from lastCommitInfo =
-      LastCommitInfo { lastCommitInfoRound = lastCommitInfo ^. PT.round
-                     , lastCommitInfoVotes = lastCommitInfo ^.. PT.votes . traverse . Lens.from voteInfo
-                     }
+    t LastCommitInfo{..} =
+      defMessage & PT.round .~ lastCommitInfoRound
+                 & PT.votes .~ lastCommitInfoVotes ^.. traverse . voteInfo
+    f a =
+      LastCommitInfo
+        { lastCommitInfoRound = a ^. PT.round
+        , lastCommitInfoVotes = a ^.. PT.votes . traverse . Lens.from voteInfo
+        }
 
-data PartSetHeader =
-  PartSetHeader { partSetHeaderTotal :: Int32
-                -- ^ total number of pieces in a PartSet
-                , partSetHeaderHash  :: ByteString
-                -- ^ Merkle root hash of those pieces
-                } deriving (Eq, Show, Generic)
+data PartSetHeader = PartSetHeader
+  { partSetHeaderTotal :: Int32
+  -- ^ total number of pieces in a PartSet
+  , partSetHeaderHash  :: ByteString
+  -- ^ Merkle root hash of those pieces
+  } deriving (Eq, Show, Generic)
 
 partSetHeader :: Iso' PartSetHeader PT.PartSetHeader
-partSetHeader = iso to from
+partSetHeader = iso t f
   where
-    to PartSetHeader{..} = defMessage & PT.total .~ partSetHeaderTotal
-                                      & PT.hash .~ partSetHeaderHash
-    from partSetHeader =
-      PartSetHeader { partSetHeaderTotal = partSetHeader ^. PT.total
-                    , partSetHeaderHash = partSetHeader ^. PT.hash
+    t PartSetHeader{..} =
+      defMessage & PT.total .~ partSetHeaderTotal
+                 & PT.hash .~ partSetHeaderHash
+    f a =
+      PartSetHeader { partSetHeaderTotal = a ^. PT.total
+                    , partSetHeaderHash = a ^. PT.hash
                     }
 
-data BlockID =
-  BlockID { blockIDHash        :: ByteString
-          -- ^ Hash of the block header
-          , blockIDPartsHeader :: Maybe PartSetHeader
-          -- ^ PartSetHeader (used internally, for clients this is basically opaque).
-          } deriving (Eq, Show, Generic)
+data BlockID = BlockID
+  { blockIDHash        :: ByteString
+  -- ^ Hash of the block header
+  , blockIDPartsHeader :: Maybe PartSetHeader
+  -- ^ PartSetHeader (used internally, for clients this is basically opaque).
+  } deriving (Eq, Show, Generic)
 
 blockID :: Iso' BlockID PT.BlockID
-blockID = iso to from
+blockID = iso t f
   where
-    to BlockID{..} = defMessage & PT.hash .~ blockIDHash
-                                & PT.maybe'partsHeader .~ blockIDPartsHeader ^? _Just . partSetHeader
-    from blockID =
-      BlockID { blockIDHash = blockID ^. PT.hash
-              , blockIDPartsHeader = blockID ^? PT.maybe'partsHeader . _Just . Lens.from partSetHeader
-              }
+    t BlockID{..} =
+      defMessage & PT.hash .~ blockIDHash
+                 & PT.maybe'partsHeader .~ blockIDPartsHeader ^? _Just . partSetHeader
+    f a =
+      BlockID
+        { blockIDHash = a ^. PT.hash
+        , blockIDPartsHeader = a ^? PT.maybe'partsHeader . _Just . Lens.from partSetHeader
+        }
 
-data Version =
-  Version { versionBlock :: Word64
-          -- ^ Protocol version of the blockchain data structures.
-          , versionApp   :: Word64
-          -- ^ Protocol version of the application.
-          } deriving (Eq, Show, Generic)
+data Version = Version
+  { versionBlock :: Word64
+  -- ^ Protocol version of the blockchain data structures.
+  , versionApp   :: Word64
+  -- ^ Protocol version of the application.
+  } deriving (Eq, Show, Generic)
 
 version :: Iso' Version PT.Version
-version = iso to from
+version = iso t f
   where
-    to Version{..} = defMessage & PT.block .~ versionBlock
-                                & PT.app .~ versionApp
-    from version = Version { versionBlock = version ^. PT.block
-                           , versionApp = version ^. PT.app
-                           }
+    t Version{..} =
+      defMessage & PT.block .~ versionBlock
+                 & PT.app .~ versionApp
+    f version =
+      Version
+        { versionBlock = a ^. PT.block
+        , versionApp = a ^. PT.app
+        }
 
-data Header =
-  Header { headerVersion            :: Maybe Version
-         -- ^ Version of the blockchain and the application
-         , headerChainId            :: Text
-         -- ^ ID of the blockchain
-         , headerHeight             :: Int64
-         -- ^ Height of the block in the chain
-         , headerTime               :: Maybe Timestamp
-         -- ^ Time of the previous block
-         , headerNumTxs             :: Int64
-         -- ^ Number of transactions in the block
-         , headerTotalTxs           :: Int64
-         -- ^ Total number of transactions in the blockchain until now
-         , headerLastBlockId        :: BlockID
-         -- ^ Hash of the previous (parent) block
-         , headerLastCommitHash     :: ByteString
-         -- ^ Hash of the previous block's commit
-         , headerDataHash           :: ByteString
-         -- ^ Hash of the validator set for this block
-         , headerValidatorsHash     :: ByteString
-         -- ^ Hash of the validator set for the next block
-         , headerNextValidatorsHash :: ByteString
-         -- ^ Hash of the consensus parameters for this block
-         , headerConsensusHash      :: ByteString
-         -- ^ Hash of the consensus parameters for this block
-         , headerAppHash            :: ByteString
-         -- ^ Data returned by the last call to Commit
-         , headerLastResultsHash    :: ByteString
-         -- ^ Hash of the ABCI results returned by the last block
-         , headerEvidenceHash       :: ByteString
-         -- ^ Hash of the evidence included in this block
-         , headerProposerAddress    :: ByteString
-         -- ^ Original proposer for the block
-         } deriving (Eq, Show, Generic)
+data Header = Header
+  { headerVersion            :: Maybe Version
+  -- ^ Version of the blockchain and the application
+  , headerChainId            :: Text
+  -- ^ ID of the blockchain
+  , headerHeight             :: Int64
+  -- ^ Height of the block in the chain
+  , headerTime               :: Maybe Timestamp
+  -- ^ Time of the previous block
+  , headerNumTxs             :: Int64
+  -- ^ Number of transactions in the block
+  , headerTotalTxs           :: Int64
+  -- ^ Total number of transactions in the blockchain until now
+  , headerLastBlockId        :: BlockID
+  -- ^ Hash of the previous (parent) block
+  , headerLastCommitHash     :: ByteString
+  -- ^ Hash of the previous block's commit
+  , headerDataHash           :: ByteString
+  -- ^ Hash of the validator set for this block
+  , headerValidatorsHash     :: ByteString
+  -- ^ Hash of the validator set for the next block
+  , headerNextValidatorsHash :: ByteString
+  -- ^ Hash of the consensus parameters for this block
+  , headerConsensusHash      :: ByteString
+  -- ^ Hash of the consensus parameters for this block
+  , headerAppHash            :: ByteString
+  -- ^ Data returned by the last call to Commit
+  , headerLastResultsHash    :: ByteString
+  -- ^ Hash of the ABCI results returned by the last block
+  , headerEvidenceHash       :: ByteString
+  -- ^ Hash of the evidence included in this block
+  , headerProposerAddress    :: ByteString
+  -- ^ Original proposer for the block
+  } deriving (Eq, Show, Generic)
 
 
 header :: Iso' Header PT.Header
-header = iso to from
+header = iso t f
   where
-    to Header{..} = defMessage & PT.maybe'version .~ headerVersion ^? _Just . version
-                               & PT.chainId .~ headerChainId
-                               & PT.height .~ headerHeight
-                               & PT.maybe'time .~ headerTime ^? _Just . timestamp
-                               & PT.numTxs .~ headerNumTxs
-                               & PT.totalTxs .~ headerTotalTxs
-                               & PT.lastBlockId .~ headerLastBlockId ^. blockID
-                               & PT.lastCommitHash .~ headerLastCommitHash
-                               & PT.dataHash .~ headerDataHash
-                               & PT.validatorsHash .~ headerValidatorsHash
-                               & PT.nextValidatorsHash .~ headerNextValidatorsHash
-                               & PT.consensusHash .~ headerConsensusHash
-                               & PT.appHash .~ headerAppHash
-                               & PT.lastResultsHash .~ headerLastResultsHash
-                               & PT.evidenceHash .~ headerEvidenceHash
-                               & PT.proposerAddress .~ headerProposerAddress
-    from header = Header { headerVersion = header ^? PT.maybe'version . _Just . Lens.from version
-                         , headerChainId = header ^. PT.chainId
-                         , headerHeight = header ^. PT.height
-                         , headerTime = header ^? PT.maybe'time . _Just . Lens.from timestamp
-                         , headerNumTxs = header ^. PT.numTxs
-                         , headerTotalTxs = header ^. PT.totalTxs
-                         , headerLastBlockId = header ^. PT.lastBlockId. Lens.from blockID
-                         , headerLastCommitHash = header ^. PT.lastCommitHash
-                         , headerDataHash = header ^. PT.dataHash
-                         , headerValidatorsHash = header ^. PT.validatorsHash
-                         , headerNextValidatorsHash = header ^. PT.nextValidatorsHash
-                         , headerConsensusHash = header ^. PT.consensusHash
-                         , headerAppHash = header ^. PT.appHash
-                         , headerLastResultsHash = header ^. PT.lastResultsHash
-                         , headerEvidenceHash = header ^. PT.evidenceHash
-                         , headerProposerAddress = header ^. PT.proposerAddress
-                         }
+    t Header{..} =
+      defMessage & PT.maybe'version .~ headerVersion ^? _Just . version
+                 & PT.chainId .~ headerChainId
+                 & PT.height .~ headerHeight
+                 & PT.maybe'time .~ headerTime ^? _Just . timestamp
+                 & PT.numTxs .~ headerNumTxs
+                 & PT.totalTxs .~ headerTotalTxs
+                 & PT.lastBlockId .~ headerLastBlockId ^. blockID
+                 & PT.lastCommitHash .~ headerLastCommitHash
+                 & PT.dataHash .~ headerDataHash
+                 & PT.validatorsHash .~ headerValidatorsHash
+                 & PT.nextValidatorsHash .~ headerNextValidatorsHash
+                 & PT.consensusHash .~ headerConsensusHash
+                 & PT.appHash .~ headerAppHash
+                 & PT.lastResultsHash .~ headerLastResultsHash
+                 & PT.evidenceHash .~ headerEvidenceHash
+                 & PT.proposerAddress .~ headerProposerAddress
+    f a =
+      Header
+        { headerVersion = a ^? PT.maybe'version . _Just . Lens.from version
+        , headerChainId = a ^. PT.chainId
+        , headerHeight = a ^. PT.height
+        , headerTime = a ^? PT.maybe'time . _Just . Lens.from timestamp
+        , headerNumTxs = a ^. PT.numTxs
+        , headerTotalTxs = a ^. PT.totalTxs
+        , headerLastBlockId = a ^. PT.lastBlockId. Lens.from blockID
+        , headerLastCommitHash = a ^. PT.lastCommitHash
+        , headerDataHash = a ^. PT.dataHash
+        , headerValidatorsHash = a ^. PT.validatorsHash
+        , headerNextValidatorsHash = a ^. PT.nextValidatorsHash
+        , headerConsensusHash = a ^. PT.consensusHash
+        , headerAppHash = a ^. PT.appHash
+        , headerLastResultsHash = a ^. PT.lastResultsHash
+        , headerEvidenceHash = a ^. PT.evidenceHash
+        , headerProposerAddress = a ^. PT.proposerAddress
+        }
 
-data Evidence =
-  Evidence { evidenceType             :: Text
-           -- ^ Type of the evidence.
-           , evidenceValidator        :: Maybe Validator
-           -- ^ The offending validator
-           , evidenceHeight           :: Int64
-           -- ^ Height when the offense was committed
-           , evidenceTime             :: Maybe Timestamp
-           -- ^ Time of the block at height Height.
-           , evidenceTotalVotingPower :: Int64
-           -- ^ Total voting power of the validator set at height Height
-           } deriving (Eq, Show, Generic)
+data Evidence = Evidence
+  { evidenceType             :: Text
+  -- ^ Type of the evidence.
+  , evidenceValidator        :: Maybe Validator
+  -- ^ The offending validator
+  , evidenceHeight           :: Int64
+  -- ^ Height when the offense was committed
+  , evidenceTime             :: Maybe Timestamp
+  -- ^ Time of the block at height Height.
+  , evidenceTotalVotingPower :: Int64
+  -- ^ Total voting power of the validator set at height Height
+  } deriving (Eq, Show, Generic)
 
 evidence :: Iso' Evidence PT.Evidence
-evidence = iso to from
+evidence = iso t f
   where
-    to Evidence{..} = defMessage & PT.type' .~ evidenceType
-                                 & PT.maybe'validator .~ evidenceValidator ^? _Just . validator
-                                 & PT.height .~ evidenceHeight
-                                 & PT.maybe'time .~ evidenceTime ^? _Just . timestamp
-                                 & PT.totalVotingPower .~ evidenceTotalVotingPower
-    from evidence =
-      Evidence { evidenceType = evidence ^. PT.type'
-               , evidenceValidator = evidence ^? PT.maybe'validator . _Just . Lens.from validator
-               , evidenceHeight = evidence ^. PT.height
-               , evidenceTime = evidence ^? PT.maybe'time . _Just . Lens.from timestamp
-               , evidenceTotalVotingPower = evidence ^. PT.totalVotingPower
-               }
+    to Evidence{..} =
+      defMessage & PT.type' .~ evidenceType
+                 & PT.maybe'validator .~ evidenceValidator ^? _Just . validator
+                 & PT.height .~ evidenceHeight
+                 & PT.maybe'time .~ evidenceTime ^? _Just . timestamp
+                 & PT.totalVotingPower .~ evidenceTotalVotingPower
+    from a =
+      Evidence
+        { evidenceType = a ^. PT.type'
+        , evidenceValidator = a ^? PT.maybe'validator . _Just . Lens.from validator
+        , evidenceHeight = a ^. PT.height
+        , evidenceTime = a ^? PT.maybe'time . _Just . Lens.from timestamp
+        , evidenceTotalVotingPower = a ^. PT.totalVotingPower
+        }
 
 
 data KVPair = KVPair
@@ -364,16 +400,16 @@ data KVPair = KVPair
   } deriving (Eq, Show, Generic)
 
 kVPair :: Iso' KVPair CT.KVPair
-kVPair = iso to from
+kVPair = iso t f
   where
-    to KVPair{..} =
+    t KVPair{..} =
       defMessage
         & CT.key .~ kVPairKey
         & CT.value .~ kVPairValue
-    from kVPair =
+    f a =
       KVPair
-        { kVPairKey = kVPair ^. CT.key
-        , kVPairValue = kVPair ^. CT.value
+        { kVPairKey = a ^. CT.key
+        , kVPairValue = a ^. CT.value
         }
 
 
@@ -383,14 +419,14 @@ data Proof = Proof
   } deriving (Eq, Show, Generic)
 
 proof :: Iso' Proof MT.Proof
-proof = iso to from
+proof = iso t f
   where
     to Proof{..} =
       defMessage
         & MT.ops .~ proofOps ^.. traverse . proofOp
-    from proof =
+    f a =
       Proof
-        { proofOps = proof ^.. MT.ops . traverse . Lens.from proofOp
+        { proofOps = a ^.. MT.ops . traverse . Lens.from proofOp
         }
 
 
@@ -404,17 +440,17 @@ data ProofOp = ProofOp
   } deriving (Eq, Show, Generic)
 
 proofOp :: Iso' ProofOp MT.ProofOp
-proofOp = iso to from
+proofOp = iso t f
   where
     to ProofOp{..} =
       defMessage
         & MT.type' .~ proofOpType
         & MT.key .~ proofOpKey
         & MT.data' .~ proofOpData
-    from proofOp =
+    from a =
       ProofOp
-        { proofOpType = proofOp ^. MT.type'
-        , proofOpKey = proofOp ^. MT.key
-        , proofOpData = proofOp ^. MT.data'
+        { proofOpType = a ^. MT.type'
+        , proofOpKey = a ^. MT.key
+        , proofOpData = a ^. MT.data'
         }
 

--- a/src/Network/ABCI/Types/Messages/Request.hs
+++ b/src/Network/ABCI/Types/Messages/Request.hs
@@ -11,6 +11,9 @@ module Network.ABCI.Types.Messages.Request
   , DeliverTx(..)
   , EndBlock(..)
   , Commit(..)
+
+  -- * ReExports
+  , MessageType(..)
   ) where
 
 import           Control.Lens                           (Iso', iso, traverse,
@@ -37,6 +40,9 @@ import           Network.ABCI.Types.Messages.Types      (MessageType(..))
 import qualified Proto.Types                            as PT
 import qualified Proto.Types_Fields                     as PT
 
+--------------------------------------------------------------------------------
+-- Request
+--------------------------------------------------------------------------------
 
 data Request (m :: MessageType) :: * where
   RequestEcho :: Echo -> Request 'MTEcho

--- a/src/Network/ABCI/Types/Messages/Request.hs
+++ b/src/Network/ABCI/Types/Messages/Request.hs
@@ -58,9 +58,9 @@ data Request (m :: MessageType) :: * where
 --------------------------------------------------------------------------------
 
 data Echo = Echo
- { echoMessage :: Text
- -- ^ A string to echo back
- } deriving (Eq, Show, Generic)
+  { echoMessage :: Text
+  -- ^ A string to echo back
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped Echo where
   type Unwrapped Echo = PT.RequestEcho
@@ -330,11 +330,13 @@ instance Wrapped EndBlock where
 data Commit =
   Commit deriving (Eq, Show, Generic)
 
-commit :: Iso' Commit PT.RequestCommit
-commit = iso t f
-  where
-    t Commit =
-      defMessage
+instance Wrapped Commit where
+  type Unwrapped Commit = PT.RequestCommit
 
-    f requestCommit =
-      Commit
+  _Wrapped' = iso t f
+    where
+      t Commit =
+        defMessage
+
+      f requestCommit =
+        Commit

--- a/src/Network/ABCI/Types/Messages/Request.hs
+++ b/src/Network/ABCI/Types/Messages/Request.hs
@@ -38,7 +38,6 @@ import qualified Proto.Types                            as PT
 import qualified Proto.Types_Fields                     as PT
 
 
-
 data Request (m :: MessageType) :: * where
   RequestEcho :: Echo -> Request 'MTEcho
   RequestFlush :: Flush -> Request 'MTFlush
@@ -56,9 +55,10 @@ data Request (m :: MessageType) :: * where
 --------------------------------------------------------------------------------
 
 data Echo =
-  Echo { echoMessage :: Text
-       -- ^ A string to echo back
-       } deriving (Eq, Show, Generic)
+  Echo
+    { echoMessage :: Text
+    -- ^ A string to echo back
+    } deriving (Eq, Show, Generic)
 
 instance Wrapped Echo where
   type Unwrapped Echo = PT.RequestEcho
@@ -68,8 +68,9 @@ instance Wrapped Echo where
       t Echo{..} =
         defMessage & PT.message .~ echoMessage
       f message =
-        Echo { echoMessage = message ^. PT.message
-             }
+        Echo
+          { echoMessage = message ^. PT.message
+          }
 
 --------------------------------------------------------------------------------
 -- Flush
@@ -91,13 +92,14 @@ instance Wrapped Flush where
 --------------------------------------------------------------------------------
 
 data Info =
-  Info { infoVersion      :: Text
-       -- ^ The Tendermint software semantic version
-       , infoBlockVersion :: Word64
-       -- ^ The Tendermint Block Protocol version
-       , infoP2pVersion   :: Word64
-       -- ^ The Tendermint P2P Protocol version
-       } deriving (Eq, Show, Generic)
+  Info
+    { infoVersion      :: Text
+    -- ^ The Tendermint software semantic version
+    , infoBlockVersion :: Word64
+    -- ^ The Tendermint Block Protocol version
+    , infoP2pVersion   :: Word64
+    -- ^ The Tendermint P2P Protocol version
+    } deriving (Eq, Show, Generic)
 
 instance Wrapped Info where
   type Unwrapped Info = PT.RequestInfo
@@ -109,21 +111,23 @@ instance Wrapped Info where
                    & PT.blockVersion .~ infoBlockVersion
                    & PT.p2pVersion .~ infoP2pVersion
       f message =
-        Info { infoVersion = message ^. PT.version
-             , infoBlockVersion = message ^. PT.blockVersion
-             , infoP2pVersion = message ^. PT.p2pVersion
-             }
+        Info
+          { infoVersion = message ^. PT.version
+          , infoBlockVersion = message ^. PT.blockVersion
+          , infoP2pVersion = message ^. PT.p2pVersion
+          }
 
 --------------------------------------------------------------------------------
 -- SetOption
 --------------------------------------------------------------------------------
 
 data SetOption =
-  SetOption { setOptionKey   :: Text
-            -- ^ Key to set
-            , setOptionValue :: Text
-            -- ^ Value to set for key
-            } deriving (Eq, Show, Generic)
+  SetOption
+    { setOptionKey   :: Text
+    -- ^ Key to set
+    , setOptionValue :: Text
+    -- ^ Value to set for key
+    } deriving (Eq, Show, Generic)
 
 instance Wrapped SetOption where
   type Unwrapped SetOption = PT.RequestSetOption
@@ -134,26 +138,28 @@ instance Wrapped SetOption where
         defMessage & PT.key .~ setOptionKey
                    & PT.value .~ setOptionValue
       f message =
-        SetOption { setOptionKey = message ^. PT.key
-                  , setOptionValue = message ^. PT.value
-                  }
+        SetOption
+          { setOptionKey = message ^. PT.key
+          , setOptionValue = message ^. PT.value
+          }
 
 --------------------------------------------------------------------------------
 -- InitChain
 --------------------------------------------------------------------------------
 
 data InitChain =
-  InitChain { initChainTime            :: Maybe Timestamp
-            -- ^ Genesis time
-            , initChainChainId         :: Text
-            -- ^ ID of the blockchain.
-            , initChainConsensusParams :: Maybe ConsensusParams
-            -- ^ Initial consensus-critical parameters.
-            , initChainValidators      :: [ValidatorUpdate]
-            -- ^ Initial genesis validators.
-            , initChainAppState        :: ByteString
-            -- ^ Serialized initial application state. Amino-encoded JSON bytes.
-            } deriving (Eq, Show, Generic)
+  InitChain
+    { initChainTime            :: Maybe Timestamp
+    -- ^ Genesis time
+    , initChainChainId         :: Text
+    -- ^ ID of the blockchain.
+    , initChainConsensusParams :: Maybe ConsensusParams
+    -- ^ Initial consensus-critical parameters.
+    , initChainValidators      :: [ValidatorUpdate]
+    -- ^ Initial genesis validators.
+    , initChainAppState        :: ByteString
+    -- ^ Serialized initial application state. Amino-encoded JSON bytes.
+    } deriving (Eq, Show, Generic)
 
 instance Wrapped InitChain where
   type Unwrapped InitChain = PT.RequestInitChain
@@ -167,27 +173,29 @@ instance Wrapped InitChain where
                    & PT.validators .~ initChainValidators ^.. traverse . validatorUpdate
                    & PT.appStateBytes .~ initChainAppState
       f message =
-        InitChain { initChainTime = message ^? PT.maybe'time . _Just . from timestamp
-                  , initChainChainId = message ^. PT.chainId
-                  , initChainConsensusParams = message ^? PT.maybe'consensusParams . _Just . from consensusParams
-                  , initChainValidators = message ^.. PT.validators . traverse . from validatorUpdate
-                  , initChainAppState = message ^. PT.appStateBytes
-                  }
+        InitChain
+          { initChainTime = message ^? PT.maybe'time . _Just . from timestamp
+          , initChainChainId = message ^. PT.chainId
+          , initChainConsensusParams = message ^? PT.maybe'consensusParams . _Just . from consensusParams
+          , initChainValidators = message ^.. PT.validators . traverse . from validatorUpdate
+          , initChainAppState = message ^. PT.appStateBytes
+          }
 
 --------------------------------------------------------------------------------
 -- Query
 --------------------------------------------------------------------------------
 
 data Query =
-  Query { queryData   :: ByteString
-        -- ^  Raw query bytes. Can be used with or in lieu of Path.
-        , queryPath   :: Text
-        -- ^ Path of request, like an HTTP GET path. Can be used with or in liue of Data.
-        , queryHeight :: Int64
-        -- ^ The block height for which you want the query
-        , queryProve  :: Bool
-        -- ^ Return Merkle proof with response if possible
-        } deriving (Eq, Show, Generic)
+  Query
+    { queryData   :: ByteString
+    -- ^  Raw query bytes. Can be used with or in lieu of Path.
+    , queryPath   :: Text
+    -- ^ Path of request, like an HTTP GET path. Can be used with or in liue of Data.
+    , queryHeight :: Int64
+    -- ^ The block height for which you want the query
+    , queryProve  :: Bool
+    -- ^ Return Merkle proof with response if possible
+    } deriving (Eq, Show, Generic)
 
 instance Wrapped Query where
   type Unwrapped Query = PT.RequestQuery
@@ -200,27 +208,29 @@ instance Wrapped Query where
                    & PT.height .~ queryHeight
                    & PT.prove .~ queryProve
       f message =
-        Query { queryData = message ^. PT.data'
-              , queryPath = message ^. PT.path
-              , queryHeight = message ^. PT.height
-              , queryProve = message ^. PT.prove
-              }
+        Query
+          { queryData = message ^. PT.data'
+          , queryPath = message ^. PT.path
+          , queryHeight = message ^. PT.height
+          , queryProve = message ^. PT.prove
+          }
 
 --------------------------------------------------------------------------------
 -- BeginBlock
 --------------------------------------------------------------------------------
 
 data BeginBlock =
-  BeginBlock { beginBlockHash                :: ByteString
-             -- ^ The block's hash. This can be derived from the block header.
-             , beginBlockHeader              :: Maybe Header
-             -- ^ The block header.
-             , beginBlockLastCommitInfo      :: Maybe LastCommitInfo
-             -- ^ Info about the last commit, including the round, and the list of
-             -- validators and which ones signed the last block.
-             , beginBlockByzantineValidators :: [Evidence]
-             -- ^ List of evidence of validators that acted maliciously.
-             } deriving (Eq, Show, Generic)
+  BeginBlock
+    { beginBlockHash                :: ByteString
+    -- ^ The block's hash. This can be derived from the block header.
+    , beginBlockHeader              :: Maybe Header
+    -- ^ The block header.
+    , beginBlockLastCommitInfo      :: Maybe LastCommitInfo
+    -- ^ Info about the last commit, including the round, and the list of
+    -- validators and which ones signed the last block.
+    , beginBlockByzantineValidators :: [Evidence]
+    -- ^ List of evidence of validators that acted maliciously.
+    } deriving (Eq, Show, Generic)
 
 instance Wrapped BeginBlock where
   type Unwrapped BeginBlock = PT.RequestBeginBlock
@@ -233,11 +243,12 @@ instance Wrapped BeginBlock where
                    & PT.maybe'lastCommitInfo .~ beginBlockLastCommitInfo ^? _Just . lastCommitInfo
                    & PT.byzantineValidators .~ beginBlockByzantineValidators ^.. traverse . evidence
       f message =
-        BeginBlock { beginBlockHash = message ^. PT.hash
-                   , beginBlockHeader = message ^? PT.maybe'header . _Just . from header
-                   , beginBlockLastCommitInfo = message ^? PT.maybe'lastCommitInfo . _Just . from lastCommitInfo
-                   , beginBlockByzantineValidators = message ^.. PT.byzantineValidators . traverse . from evidence
-                   }
+        BeginBlock
+          { beginBlockHash = message ^. PT.hash
+          , beginBlockHeader = message ^? PT.maybe'header . _Just . from header
+          , beginBlockLastCommitInfo = message ^? PT.maybe'lastCommitInfo . _Just . from lastCommitInfo
+          , beginBlockByzantineValidators = message ^.. PT.byzantineValidators . traverse . from evidence
+          }
 
 --------------------------------------------------------------------------------
 -- CheckTx
@@ -260,8 +271,9 @@ instance Wrapped CheckTx where
           & PT.tx .~ checkTxTx
 
       f message =
-        CheckTx { checkTxTx = message ^. PT.tx
-                }
+        CheckTx
+          { checkTxTx = message ^. PT.tx
+          }
 
 --------------------------------------------------------------------------------
 -- DeliverTx
@@ -283,14 +295,16 @@ instance Wrapped DeliverTx where
          & PT.tx .~ deliverTxTx
 
      f message =
-       DeliverTx { deliverTxTx = message ^. PT.tx
-                 }
+       DeliverTx
+         { deliverTxTx = message ^. PT.tx
+         }
 
 --------------------------------------------------------------------------------
 -- EndBlock
 --------------------------------------------------------------------------------
 
-data EndBlock  = EndBlock
+data EndBlock =
+  EndBlock
     { endBlockHeight :: Int64
     -- ^ Height of the block just executed.
     } deriving (Eq, Show, Generic)
@@ -305,8 +319,9 @@ instance Wrapped EndBlock where
           & PT.height .~ endBlockHeight
 
       f message =
-        EndBlock { endBlockHeight = message ^. PT.height
-                 }
+        EndBlock
+          { endBlockHeight = message ^. PT.height
+          }
 
 --------------------------------------------------------------------------------
 -- Commit

--- a/src/Network/ABCI/Types/Messages/Request.hs
+++ b/src/Network/ABCI/Types/Messages/Request.hs
@@ -18,25 +18,22 @@ module Network.ABCI.Types.Messages.Request
 
 import           Control.Lens                           (Iso', iso, traverse,
                                                          (&), (.~), (^.), (^..),
-                                                         (^?), _Just, from)
-import           Control.Lens.Wrapped                   (Wrapped(..))
+                                                         (^?), _Just)
+import           Control.Lens.Wrapped                   (Wrapped (..),
+                                                         _Unwrapped')
 import           Data.ByteString                        (ByteString)
 import           Data.Int                               (Int64)
 import           Data.ProtoLens.Message                 (Message (defMessage))
 import           Data.Text                              (Text)
 import           Data.Word                              (Word64)
 import           GHC.Generics                           (Generic)
-import           Network.ABCI.Types.Messages.FieldTypes (ConsensusParams(..),
-                                                         Evidence(..), Header(..),
-                                                         LastCommitInfo(..),
-                                                         Timestamp(..),
-                                                         ValidatorUpdate(..),
-                                                         consensusParams,
-                                                         evidence, header,
-                                                         lastCommitInfo,
-                                                         timestamp,
-                                                         validatorUpdate)
-import           Network.ABCI.Types.Messages.Types      (MessageType(..))
+import           Network.ABCI.Types.Messages.FieldTypes (ConsensusParams (..),
+                                                         Evidence (..),
+                                                         Header (..),
+                                                         LastCommitInfo (..),
+                                                         Timestamp (..),
+                                                         ValidatorUpdate (..))
+import           Network.ABCI.Types.Messages.Types      (MessageType (..))
 import qualified Proto.Types                            as PT
 import qualified Proto.Types_Fields                     as PT
 
@@ -71,7 +68,8 @@ instance Wrapped Echo where
   _Wrapped' = iso t f
     where
       t Echo{..} =
-        defMessage & PT.message .~ echoMessage
+        defMessage
+          & PT.message .~ echoMessage
       f message =
         Echo
           { echoMessage = message ^. PT.message
@@ -111,9 +109,10 @@ instance Wrapped Info where
   _Wrapped' = iso t f
     where
       t Info{..} =
-        defMessage & PT.version .~ infoVersion
-                   & PT.blockVersion .~ infoBlockVersion
-                   & PT.p2pVersion .~ infoP2pVersion
+        defMessage
+          & PT.version .~ infoVersion
+          & PT.blockVersion .~ infoBlockVersion
+          & PT.p2pVersion .~ infoP2pVersion
       f message =
         Info
           { infoVersion = message ^. PT.version
@@ -138,8 +137,9 @@ instance Wrapped SetOption where
   _Wrapped' = iso t f
     where
       t SetOption{..} =
-        defMessage & PT.key .~ setOptionKey
-                   & PT.value .~ setOptionValue
+        defMessage
+          & PT.key .~ setOptionKey
+          & PT.value .~ setOptionValue
       f message =
         SetOption
           { setOptionKey = message ^. PT.key
@@ -169,17 +169,18 @@ instance Wrapped InitChain where
   _Wrapped' = iso t f
     where
       t InitChain{..} =
-        defMessage & PT.maybe'time .~ initChainTime ^? _Just . timestamp
-                   & PT.chainId .~ initChainChainId
-                   & PT.maybe'consensusParams .~ initChainConsensusParams ^? _Just . consensusParams
-                   & PT.validators .~ initChainValidators ^.. traverse . validatorUpdate
-                   & PT.appStateBytes .~ initChainAppState
+        defMessage
+          & PT.maybe'time .~ initChainTime ^? _Just . _Wrapped'
+          & PT.chainId .~ initChainChainId
+          & PT.maybe'consensusParams .~ initChainConsensusParams ^? _Just . _Wrapped'
+          & PT.validators .~ initChainValidators ^.. traverse . _Wrapped'
+          & PT.appStateBytes .~ initChainAppState
       f message =
         InitChain
-          { initChainTime = message ^? PT.maybe'time . _Just . from timestamp
+          { initChainTime = message ^? PT.maybe'time . _Just . _Unwrapped'
           , initChainChainId = message ^. PT.chainId
-          , initChainConsensusParams = message ^? PT.maybe'consensusParams . _Just . from consensusParams
-          , initChainValidators = message ^.. PT.validators . traverse . from validatorUpdate
+          , initChainConsensusParams = message ^? PT.maybe'consensusParams . _Just . _Unwrapped'
+          , initChainValidators = message ^.. PT.validators . traverse . _Unwrapped'
           , initChainAppState = message ^. PT.appStateBytes
           }
 
@@ -204,10 +205,11 @@ instance Wrapped Query where
   _Wrapped' = iso t f
     where
       t Query{..} =
-        defMessage & PT.data' .~ queryData
-                   & PT.path .~ queryPath
-                   & PT.height .~ queryHeight
-                   & PT.prove .~ queryProve
+        defMessage
+          & PT.data' .~ queryData
+          & PT.path .~ queryPath
+          & PT.height .~ queryHeight
+          & PT.prove .~ queryProve
       f message =
         Query
           { queryData = message ^. PT.data'
@@ -238,16 +240,17 @@ instance Wrapped BeginBlock where
   _Wrapped' = iso t f
     where
       t BeginBlock{..} =
-        defMessage & PT.hash .~ beginBlockHash
-                   & PT.maybe'header .~ beginBlockHeader ^? _Just . header
-                   & PT.maybe'lastCommitInfo .~ beginBlockLastCommitInfo ^? _Just . lastCommitInfo
-                   & PT.byzantineValidators .~ beginBlockByzantineValidators ^.. traverse . evidence
+        defMessage
+          & PT.hash .~ beginBlockHash
+          & PT.maybe'header .~ beginBlockHeader ^? _Just . _Wrapped'
+          & PT.maybe'lastCommitInfo .~ beginBlockLastCommitInfo ^? _Just . _Wrapped'
+          & PT.byzantineValidators .~ beginBlockByzantineValidators ^.. traverse . _Wrapped'
       f message =
         BeginBlock
           { beginBlockHash = message ^. PT.hash
-          , beginBlockHeader = message ^? PT.maybe'header . _Just . from header
-          , beginBlockLastCommitInfo = message ^? PT.maybe'lastCommitInfo . _Just . from lastCommitInfo
-          , beginBlockByzantineValidators = message ^.. PT.byzantineValidators . traverse . from evidence
+          , beginBlockHeader = message ^? PT.maybe'header . _Just . _Unwrapped'
+          , beginBlockLastCommitInfo = message ^? PT.maybe'lastCommitInfo . _Just . _Unwrapped'
+          , beginBlockByzantineValidators = message ^.. PT.byzantineValidators . traverse . _Unwrapped'
           }
 
 --------------------------------------------------------------------------------

--- a/src/Network/ABCI/Types/Messages/Request.hs
+++ b/src/Network/ABCI/Types/Messages/Request.hs
@@ -54,11 +54,10 @@ data Request (m :: MessageType) :: * where
 -- Echo
 --------------------------------------------------------------------------------
 
-data Echo =
-  Echo
-    { echoMessage :: Text
-    -- ^ A string to echo back
-    } deriving (Eq, Show, Generic)
+data Echo = Echo
+ { echoMessage :: Text
+ -- ^ A string to echo back
+ } deriving (Eq, Show, Generic)
 
 instance Wrapped Echo where
   type Unwrapped Echo = PT.RequestEcho
@@ -91,15 +90,14 @@ instance Wrapped Flush where
 -- Info
 --------------------------------------------------------------------------------
 
-data Info =
-  Info
-    { infoVersion      :: Text
-    -- ^ The Tendermint software semantic version
-    , infoBlockVersion :: Word64
-    -- ^ The Tendermint Block Protocol version
-    , infoP2pVersion   :: Word64
-    -- ^ The Tendermint P2P Protocol version
-    } deriving (Eq, Show, Generic)
+data Info = Info
+  { infoVersion      :: Text
+  -- ^ The Tendermint software semantic version
+  , infoBlockVersion :: Word64
+  -- ^ The Tendermint Block Protocol version
+  , infoP2pVersion   :: Word64
+  -- ^ The Tendermint P2P Protocol version
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped Info where
   type Unwrapped Info = PT.RequestInfo
@@ -121,13 +119,12 @@ instance Wrapped Info where
 -- SetOption
 --------------------------------------------------------------------------------
 
-data SetOption =
-  SetOption
-    { setOptionKey   :: Text
-    -- ^ Key to set
-    , setOptionValue :: Text
-    -- ^ Value to set for key
-    } deriving (Eq, Show, Generic)
+data SetOption = SetOption
+  { setOptionKey   :: Text
+  -- ^ Key to set
+  , setOptionValue :: Text
+  -- ^ Value to set for key
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped SetOption where
   type Unwrapped SetOption = PT.RequestSetOption
@@ -147,19 +144,18 @@ instance Wrapped SetOption where
 -- InitChain
 --------------------------------------------------------------------------------
 
-data InitChain =
-  InitChain
-    { initChainTime            :: Maybe Timestamp
-    -- ^ Genesis time
-    , initChainChainId         :: Text
-    -- ^ ID of the blockchain.
-    , initChainConsensusParams :: Maybe ConsensusParams
-    -- ^ Initial consensus-critical parameters.
-    , initChainValidators      :: [ValidatorUpdate]
-    -- ^ Initial genesis validators.
-    , initChainAppState        :: ByteString
-    -- ^ Serialized initial application state. Amino-encoded JSON bytes.
-    } deriving (Eq, Show, Generic)
+data InitChain = InitChain
+  { initChainTime            :: Maybe Timestamp
+  -- ^ Genesis time
+  , initChainChainId         :: Text
+  -- ^ ID of the blockchain.
+  , initChainConsensusParams :: Maybe ConsensusParams
+  -- ^ Initial consensus-critical parameters.
+  , initChainValidators      :: [ValidatorUpdate]
+  -- ^ Initial genesis validators.
+  , initChainAppState        :: ByteString
+  -- ^ Serialized initial application state. Amino-encoded JSON bytes.
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped InitChain where
   type Unwrapped InitChain = PT.RequestInitChain
@@ -185,17 +181,16 @@ instance Wrapped InitChain where
 -- Query
 --------------------------------------------------------------------------------
 
-data Query =
-  Query
-    { queryData   :: ByteString
-    -- ^  Raw query bytes. Can be used with or in lieu of Path.
-    , queryPath   :: Text
-    -- ^ Path of request, like an HTTP GET path. Can be used with or in liue of Data.
-    , queryHeight :: Int64
-    -- ^ The block height for which you want the query
-    , queryProve  :: Bool
-    -- ^ Return Merkle proof with response if possible
-    } deriving (Eq, Show, Generic)
+data Query = Query
+  { queryData   :: ByteString
+  -- ^  Raw query bytes. Can be used with or in lieu of Path.
+  , queryPath   :: Text
+  -- ^ Path of request, like an HTTP GET path. Can be used with or in liue of Data.
+  , queryHeight :: Int64
+  -- ^ The block height for which you want the query
+  , queryProve  :: Bool
+  -- ^ Return Merkle proof with response if possible
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped Query where
   type Unwrapped Query = PT.RequestQuery
@@ -219,18 +214,17 @@ instance Wrapped Query where
 -- BeginBlock
 --------------------------------------------------------------------------------
 
-data BeginBlock =
-  BeginBlock
-    { beginBlockHash                :: ByteString
-    -- ^ The block's hash. This can be derived from the block header.
-    , beginBlockHeader              :: Maybe Header
-    -- ^ The block header.
-    , beginBlockLastCommitInfo      :: Maybe LastCommitInfo
-    -- ^ Info about the last commit, including the round, and the list of
-    -- validators and which ones signed the last block.
-    , beginBlockByzantineValidators :: [Evidence]
-    -- ^ List of evidence of validators that acted maliciously.
-    } deriving (Eq, Show, Generic)
+data BeginBlock = BeginBlock
+  { beginBlockHash                :: ByteString
+  -- ^ The block's hash. This can be derived from the block header.
+  , beginBlockHeader              :: Maybe Header
+  -- ^ The block header.
+  , beginBlockLastCommitInfo      :: Maybe LastCommitInfo
+  -- ^ Info about the last commit, including the round, and the list of
+  -- validators and which ones signed the last block.
+  , beginBlockByzantineValidators :: [Evidence]
+  -- ^ List of evidence of validators that acted maliciously.
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped BeginBlock where
   type Unwrapped BeginBlock = PT.RequestBeginBlock
@@ -255,11 +249,10 @@ instance Wrapped BeginBlock where
 --------------------------------------------------------------------------------
 
 -- TODO: figure out what happened to Type CheckTxType field
-data CheckTx =
-  CheckTx
-    { checkTxTx :: ByteString
-    -- ^ The request transaction bytes
-    } deriving (Eq, Show, Generic)
+data CheckTx = CheckTx
+  { checkTxTx :: ByteString
+  -- ^ The request transaction bytes
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped CheckTx where
   type Unwrapped CheckTx = PT.RequestCheckTx
@@ -279,11 +272,10 @@ instance Wrapped CheckTx where
 -- DeliverTx
 --------------------------------------------------------------------------------
 
-data DeliverTx =
-  DeliverTx
-    { deliverTxTx :: ByteString
-    -- ^ The request transaction bytes.
-    } deriving (Eq, Show, Generic)
+data DeliverTx = DeliverTx
+  { deliverTxTx :: ByteString
+  -- ^ The request transaction bytes.
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped DeliverTx where
   type Unwrapped DeliverTx = PT.RequestDeliverTx
@@ -303,11 +295,10 @@ instance Wrapped DeliverTx where
 -- EndBlock
 --------------------------------------------------------------------------------
 
-data EndBlock =
-  EndBlock
-    { endBlockHeight :: Int64
-    -- ^ Height of the block just executed.
-    } deriving (Eq, Show, Generic)
+data EndBlock = EndBlock
+  { endBlockHeight :: Int64
+  -- ^ Height of the block just executed.
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped EndBlock where
   type Unwrapped EndBlock = PT.RequestEndBlock

--- a/src/Network/ABCI/Types/Messages/Response.hs
+++ b/src/Network/ABCI/Types/Messages/Response.hs
@@ -29,11 +29,10 @@ import qualified Proto.Types_Fields                     as PT
 -- Echo
 --------------------------------------------------------------------------------
 
-data Echo =
-  Echo
-    { echoMessage :: Text
-    -- ^ The input string
-    } deriving (Eq, Show, Generic)
+data Echo = Echo
+ { echoMessage :: Text
+ -- ^ The input string
+ } deriving (Eq, Show, Generic)
 
 instance Wrapped Echo where
   type Unwrapped Echo = PT.ResponseEcho
@@ -108,15 +107,14 @@ instance Wrapped Info where
 -- SetOption
 --------------------------------------------------------------------------------
 
-data SetOption =
-  SetOption
-    { setOptionCode :: Word32
-    -- ^ Response code
-    , setOptionLog  :: Text
-    -- ^ The output of the application's logger. May be non-deterministic.
-    , setOptionInfo :: Text
-    -- ^ Additional information. May be non-deterministic.
-    } deriving (Eq, Show, Generic)
+data SetOption = SetOption
+  { setOptionCode :: Word32
+  -- ^ Response code
+  , setOptionLog  :: Text
+  -- ^ The output of the application's logger. May be non-deterministic.
+  , setOptionInfo :: Text
+  -- ^ Additional information. May be non-deterministic.
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped SetOption where
   type Unwrapped SetOption = PT.ResponseSetOption
@@ -139,13 +137,12 @@ instance Wrapped SetOption where
 -- InitChain
 --------------------------------------------------------------------------------
 
-data InitChain =
-  InitChain
-    { initChainConsensusParams :: Maybe ConsensusParams
-    -- ^ Initial consensus-critical parameters.
-    , initChainValidators      :: [ValidatorUpdate]
-    -- ^ Initial validator set (if non empty).
-    } deriving (Eq, Show, Generic)
+data InitChain = InitChain
+  { initChainConsensusParams :: Maybe ConsensusParams
+  -- ^ Initial consensus-critical parameters.
+  , initChainValidators      :: [ValidatorUpdate]
+  -- ^ Initial validator set (if non empty).
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped InitChain where
   type Unwrapped InitChain = PT.ResponseInitChain
@@ -166,28 +163,27 @@ instance Wrapped InitChain where
 -- Query
 --------------------------------------------------------------------------------
 
-data Query =
-  Query
-    { queryCode      :: Word32
-    -- ^ Response code.
-    , queryLog       :: Text
-    -- ^ The output of the application's logger. May be non-deterministic.
-    , queryInfo      :: Text
-    -- ^ Additional information. May be non-deterministic.
-    , queryIndex     :: Int64
-    -- ^ The index of the key in the tree.
-    , queryKey       :: ByteString
-    -- ^ The key of the matching data.
-    , queryValue     :: ByteString
-    -- ^ The value of the matching data.
-    , queryProof     :: Maybe Proof
-    -- ^ Serialized proof for the value data, if requested, to be verified against
-    -- the AppHash for the given Height.
-    , queryHeight    :: Int64
-    -- ^ The block height from which data was derived.
-    , queryCodespace :: Text
-    -- ^ Namespace for the Code.
-    } deriving (Eq, Show, Generic)
+data Query = Query
+  { queryCode      :: Word32
+  -- ^ Response code.
+  , queryLog       :: Text
+  -- ^ The output of the application's logger. May be non-deterministic.
+  , queryInfo      :: Text
+  -- ^ Additional information. May be non-deterministic.
+  , queryIndex     :: Int64
+  -- ^ The index of the key in the tree.
+  , queryKey       :: ByteString
+  -- ^ The key of the matching data.
+  , queryValue     :: ByteString
+  -- ^ The value of the matching data.
+  , queryProof     :: Maybe Proof
+  -- ^ Serialized proof for the value data, if requested, to be verified against
+  -- the AppHash for the given Height.
+  , queryHeight    :: Int64
+  -- ^ The block height from which data was derived.
+  , queryCodespace :: Text
+  -- ^ Namespace for the Code.
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped Query where
   type Unwrapped Query = PT.ResponseQuery
@@ -222,11 +218,10 @@ instance Wrapped Query where
 -- BeginBlock
 --------------------------------------------------------------------------------
 
-data BeginBlock =
-  BeginBlock
-    { beginBlockTags :: [KVPair]
-    -- ^ Key-Value tags for filtering and indexing
-    } deriving (Eq, Show, Generic)
+data BeginBlock = BeginBlock
+  { beginBlockTags :: [KVPair]
+  -- ^ Key-Value tags for filtering and indexing
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped BeginBlock where
   type Unwrapped BeginBlock = PT.ResponseBeginBlock
@@ -245,25 +240,24 @@ instance Wrapped BeginBlock where
 -- CheckTx
 --------------------------------------------------------------------------------
 
-data CheckTx =
-  CheckTx
-    { checkTxCode      :: Word32
-    -- ^ Response code
-    , checkTxData      :: ByteString
-    -- ^ Result bytes, if any.
-    , checkTxLog       :: Text
-    -- ^ The output of the application's logger.
-    , checkTxInfo      :: Text
-    -- ^ Additional information.
-    , checkTxGasWanted :: Int64
-    -- ^ Amount of gas requested for transaction.
-    , checkTxGasUsed   :: Int64
-    -- ^ Amount of gas consumed by transaction.
-    , checkTxTags      :: [KVPair]
-    -- ^ Key-Value tags for filtering and indexing transactions (eg. by account).
-    , checkTxCodespace :: Text
-    -- ^ Namespace for the Code.
-    } deriving (Eq, Show, Generic)
+data CheckTx = CheckTx
+  { checkTxCode      :: Word32
+  -- ^ Response code
+  , checkTxData      :: ByteString
+  -- ^ Result bytes, if any.
+  , checkTxLog       :: Text
+  -- ^ The output of the application's logger.
+  , checkTxInfo      :: Text
+  -- ^ Additional information.
+  , checkTxGasWanted :: Int64
+  -- ^ Amount of gas requested for transaction.
+  , checkTxGasUsed   :: Int64
+  -- ^ Amount of gas consumed by transaction.
+  , checkTxTags      :: [KVPair]
+  -- ^ Key-Value tags for filtering and indexing transactions (eg. by account).
+  , checkTxCodespace :: Text
+  -- ^ Namespace for the Code.
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped CheckTx where
   type Unwrapped CheckTx = PT.ResponseCheckTx
@@ -296,25 +290,24 @@ instance Wrapped CheckTx where
 -- DeliverTx
 --------------------------------------------------------------------------------
 
-data DeliverTx =
-  DeliverTx
-    { deliverTxCode      :: Word32
-    -- ^ Response code.
-    , deliverTxData      :: ByteString
-    -- ^ Result bytes, if any.
-    , deliverTxLog       :: Text
-    -- ^ The output of the application's logger. May be non-deterministic.
-    , deliverTxInfo      :: Text
-    -- ^ Additional information.
-    , deliverTxGasWanted :: Int64
-    -- ^ Amount of gas requested for transaction.
-    , deliverTxGasUsed   :: Int64
-    -- ^ Amount of gas consumed by transaction.
-    , deliverTxTags      :: [KVPair]
-    -- ^  Key-Value tags for filtering and indexing transactions (eg. by account).
-    , deliverTxCodespace :: Text
-    -- ^ Namespace for the Code.
-    } deriving (Eq, Show, Generic)
+data DeliverTx = DeliverTx
+  { deliverTxCode      :: Word32
+  -- ^ Response code.
+  , deliverTxData      :: ByteString
+  -- ^ Result bytes, if any.
+  , deliverTxLog       :: Text
+  -- ^ The output of the application's logger. May be non-deterministic.
+  , deliverTxInfo      :: Text
+  -- ^ Additional information.
+  , deliverTxGasWanted :: Int64
+  -- ^ Amount of gas requested for transaction.
+  , deliverTxGasUsed   :: Int64
+  -- ^ Amount of gas consumed by transaction.
+  , deliverTxTags      :: [KVPair]
+  -- ^  Key-Value tags for filtering and indexing transactions (eg. by account).
+  , deliverTxCodespace :: Text
+  -- ^ Namespace for the Code.
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped DeliverTx where
   type Unwrapped DeliverTx = PT.ResponseDeliverTx
@@ -347,15 +340,14 @@ instance Wrapped DeliverTx where
 -- EndBlock
 --------------------------------------------------------------------------------
 
-data EndBlock =
-  EndBlock
-    { endBlockValidatorUpdates      :: [ValidatorUpdate]
-    -- ^ Changes to validator set (set voting power to 0 to remove).
-    , endBlockConsensusParamUpdates :: Maybe ConsensusParams
-    -- ^ Changes to consensus-critical time, size, and other parameters.
-    , endBlockTags                  :: [KVPair]
-    -- ^ Key-Value tags for filtering and indexing
-    } deriving (Eq, Show, Generic)
+data EndBlock = EndBlock
+  { endBlockValidatorUpdates      :: [ValidatorUpdate]
+  -- ^ Changes to validator set (set voting power to 0 to remove).
+  , endBlockConsensusParamUpdates :: Maybe ConsensusParams
+  -- ^ Changes to consensus-critical time, size, and other parameters.
+  , endBlockTags                  :: [KVPair]
+  -- ^ Key-Value tags for filtering and indexing
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped EndBlock where
   type Unwrapped EndBlock = PT.ResponseEndBlock
@@ -378,11 +370,10 @@ instance Wrapped EndBlock where
 -- Commit
 --------------------------------------------------------------------------------
 
-data Commit =
-  Commit
-    { commitData :: ByteString
-    -- ^ The Merkle root hash of the application state
-    } deriving (Eq, Show, Generic)
+data Commit = Commit
+  { commitData :: ByteString
+  -- ^ The Merkle root hash of the application state
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped Commit where
   type Unwrapped Commit = PT.ResponseCommit
@@ -401,10 +392,9 @@ instance Wrapped Commit where
 -- Exception
 --------------------------------------------------------------------------------
 
-data Exception =
-  Exception
-    { exceptionError :: Text
-    } deriving (Eq, Show, Generic)
+data Exception = Exception
+  { exceptionError :: Text
+  } deriving (Eq, Show, Generic)
 
 exception :: Iso' Exception PT.ResponseException
 exception = iso to from

--- a/src/Network/ABCI/Types/Messages/Response.hs
+++ b/src/Network/ABCI/Types/Messages/Response.hs
@@ -1,26 +1,38 @@
-module Network.ABCI.Types.Messages.Response where
+module Network.ABCI.Types.Messages.Response
+  ( Response(..)
+
+  -- * Request Message Types
+  , Echo(..)
+  , Flush(..)
+  , Info(..)
+  , Query(..)
+  , BeginBlock(..)
+  , CheckTx(..)
+  , DeliverTx(..)
+  , EndBlock(..)
+  , Commit(..)
+
+  -- * ReExports
+  , MessageType(..)
+  ) where
 
 import           Control.Lens                           (Iso', iso, traverse,
                                                          (&), (.~), (^.), (^..),
-                                                         (^?), _Just, from)
-import           Control.Lens.Wrapped                   (Wrapped(..))
+                                                         (^?), _Just)
+import           Control.Lens.Wrapped                   (Wrapped (..),
+                                                         _Unwrapped')
 import           Data.ByteString                        (ByteString)
 import           Data.Int                               (Int64)
 import           Data.ProtoLens.Message                 (Message (defMessage))
 import           Data.Text                              (Text)
 import           Data.Word                              (Word32, Word64)
 import           GHC.Generics                           (Generic)
-import           Network.ABCI.Types.Messages.Types      (MessageType(..))
 import           Network.ABCI.Types.Messages.FieldTypes (ConsensusParams,
                                                          Evidence, Header,
                                                          KVPair, LastCommitInfo,
                                                          Proof, Timestamp,
-                                                         ValidatorUpdate,
-                                                         consensusParams,
-                                                         evidence, header,
-                                                         kVPair, lastCommitInfo,
-                                                         proof, timestamp,
-                                                         validatorUpdate)
+                                                         ValidatorUpdate)
+import           Network.ABCI.Types.Messages.Types      (MessageType (..))
 import qualified Proto.Types                            as PT
 import qualified Proto.Types_Fields                     as PT
 
@@ -167,12 +179,12 @@ instance Wrapped InitChain where
     where
       t InitChain{..} =
         defMessage
-          & PT.maybe'consensusParams .~ initChainConsensusParams ^? _Just . consensusParams
-          & PT.validators .~ initChainValidators ^.. traverse . validatorUpdate
+          & PT.maybe'consensusParams .~ initChainConsensusParams ^? _Just . _Wrapped'
+          & PT.validators .~ initChainValidators ^.. traverse . _Wrapped'
       f message =
         InitChain
-          { initChainConsensusParams = message ^? PT.maybe'consensusParams . _Just . from consensusParams
-          , initChainValidators = message ^.. PT.validators . traverse . from validatorUpdate
+          { initChainConsensusParams = message ^? PT.maybe'consensusParams . _Just . _Unwrapped'
+          , initChainValidators = message ^.. PT.validators . traverse . _Unwrapped'
           }
 
 --------------------------------------------------------------------------------
@@ -214,7 +226,7 @@ instance Wrapped Query where
           & PT.index .~ queryIndex
           & PT.key .~ queryKey
           & PT.value .~ queryValue
-          & PT.maybe'proof .~ queryProof ^? _Just . proof
+          & PT.maybe'proof .~ queryProof ^? _Just . _Wrapped'
           & PT.height .~ queryHeight
           & PT.codespace .~ queryCodespace
       f message =
@@ -225,7 +237,7 @@ instance Wrapped Query where
           , queryIndex = message ^. PT.index
           , queryKey = message ^. PT.key
           , queryValue = message ^. PT.value
-          , queryProof = message ^? PT.maybe'proof . _Just . from proof
+          , queryProof = message ^? PT.maybe'proof . _Just . _Unwrapped'
           , queryHeight = message ^. PT.height
           , queryCodespace = message ^. PT.codespace
           }
@@ -246,10 +258,10 @@ instance Wrapped BeginBlock where
     where
       t BeginBlock{..} =
         defMessage
-          & PT.tags .~ beginBlockTags ^.. traverse . kVPair
+          & PT.tags .~ beginBlockTags ^.. traverse . _Wrapped'
       f message =
         BeginBlock
-          { beginBlockTags = message ^.. PT.tags . traverse . from kVPair
+          { beginBlockTags = message ^.. PT.tags . traverse . _Unwrapped'
           }
 
 --------------------------------------------------------------------------------
@@ -288,7 +300,7 @@ instance Wrapped CheckTx where
           & PT.info .~ checkTxInfo
           & PT.gasWanted .~ checkTxGasWanted
           & PT.gasUsed .~ checkTxGasUsed
-          & PT.tags .~ checkTxTags ^.. traverse . kVPair
+          & PT.tags .~ checkTxTags ^.. traverse . _Wrapped'
           & PT.codespace .~ checkTxCodespace
       f message =
         CheckTx
@@ -298,7 +310,7 @@ instance Wrapped CheckTx where
           , checkTxInfo = message ^. PT.info
           , checkTxGasWanted = message ^. PT.gasWanted
           , checkTxGasUsed = message ^. PT.gasUsed
-          , checkTxTags = message ^.. PT.tags . traverse . from kVPair
+          , checkTxTags = message ^.. PT.tags . traverse . _Unwrapped'
           , checkTxCodespace = message ^. PT.codespace
           }
 
@@ -338,7 +350,7 @@ instance Wrapped DeliverTx where
           & PT.info .~ deliverTxInfo
           & PT.gasWanted .~ deliverTxGasWanted
           & PT.gasUsed .~ deliverTxGasUsed
-          & PT.tags .~ deliverTxTags ^.. traverse . kVPair
+          & PT.tags .~ deliverTxTags ^.. traverse . _Wrapped'
           & PT.codespace .~ deliverTxCodespace
       f responseDeliverTx =
         DeliverTx
@@ -348,7 +360,7 @@ instance Wrapped DeliverTx where
           , deliverTxInfo = responseDeliverTx ^. PT.info
           , deliverTxGasWanted = responseDeliverTx ^. PT.gasWanted
           , deliverTxGasUsed = responseDeliverTx ^. PT.gasUsed
-          , deliverTxTags = responseDeliverTx ^.. PT.tags . traverse . from kVPair
+          , deliverTxTags = responseDeliverTx ^.. PT.tags . traverse . _Unwrapped'
           , deliverTxCodespace = responseDeliverTx ^. PT.codespace
           }
 
@@ -372,14 +384,14 @@ instance Wrapped EndBlock where
     where
       t EndBlock{..} =
         defMessage
-          & PT.validatorUpdates .~ endBlockValidatorUpdates ^.. traverse . validatorUpdate
-          & PT.maybe'consensusParamUpdates .~ endBlockConsensusParamUpdates ^? _Just . consensusParams
-          & PT.tags .~ endBlockTags ^.. traverse . kVPair
+          & PT.validatorUpdates .~ endBlockValidatorUpdates ^.. traverse . _Wrapped'
+          & PT.maybe'consensusParamUpdates .~ endBlockConsensusParamUpdates ^? _Just . _Wrapped'
+          & PT.tags .~ endBlockTags ^.. traverse . _Wrapped'
       f message =
         EndBlock
-          { endBlockValidatorUpdates = message ^.. PT.validatorUpdates . traverse . from validatorUpdate
-          , endBlockConsensusParamUpdates = message ^? PT.maybe'consensusParamUpdates . _Just . from consensusParams
-          , endBlockTags = message ^.. PT.tags . traverse . from kVPair
+          { endBlockValidatorUpdates = message ^.. PT.validatorUpdates . traverse . _Unwrapped'
+          , endBlockConsensusParamUpdates = message ^? PT.maybe'consensusParamUpdates . _Just . _Unwrapped'
+          , endBlockTags = message ^.. PT.tags . traverse . _Unwrapped'
           }
 
 --------------------------------------------------------------------------------
@@ -413,12 +425,12 @@ data Exception = Exception
   } deriving (Eq, Show, Generic)
 
 exception :: Iso' Exception PT.ResponseException
-exception = iso to from
+exception = iso t f
   where
-    to Exception{..} =
+    t Exception{..} =
       defMessage
         & PT.error .~ exceptionError
-    from responseException =
+    f responseException =
       Exception
         { exceptionError = responseException ^. PT.error
         }

--- a/src/Network/ABCI/Types/Messages/Response.hs
+++ b/src/Network/ABCI/Types/Messages/Response.hs
@@ -96,12 +96,13 @@ instance Wrapped Info where
         & PT.lastBlockHeight .~ infoLastBlockHeight
         & PT.lastBlockAppHash .~ infoLastBlockAppHash
      f message =
-       Info { infoData = message ^. PT.data'
-            , infoVersion = message ^. PT.version
-            , infoAppVersion = message ^. PT.appVersion
-            , infoLastBlockHeight = message ^. PT.lastBlockHeight
-            , infoLastBlockAppHash = message ^. PT.lastBlockAppHash
-            }
+       Info
+         { infoData = message ^. PT.data'
+         , infoVersion = message ^. PT.version
+         , infoAppVersion = message ^. PT.appVersion
+         , infoLastBlockHeight = message ^. PT.lastBlockHeight
+         , infoLastBlockAppHash = message ^. PT.lastBlockAppHash
+         }
 
 --------------------------------------------------------------------------------
 -- SetOption
@@ -128,10 +129,11 @@ instance Wrapped SetOption where
           & PT.log .~ setOptionLog
           & PT.info .~ setOptionInfo
       f message =
-        SetOption { setOptionCode = message ^. PT.code
-                  , setOptionLog = message ^. PT.log
-                  , setOptionInfo = message ^. PT.info
-                  }
+        SetOption
+          { setOptionCode = message ^. PT.code
+          , setOptionLog = message ^. PT.log
+          , setOptionInfo = message ^. PT.info
+          }
 
 --------------------------------------------------------------------------------
 -- InitChain
@@ -155,9 +157,10 @@ instance Wrapped InitChain where
           & PT.maybe'consensusParams .~ initChainConsensusParams ^? _Just . consensusParams
           & PT.validators .~ initChainValidators ^.. traverse . validatorUpdate
       f message =
-        InitChain { initChainConsensusParams = message ^? PT.maybe'consensusParams . _Just . Lens.from consensusParams
-                  , initChainValidators = message ^.. PT.validators . traverse . Lens.from validatorUpdate
-                  }
+        InitChain
+          { initChainConsensusParams = message ^? PT.maybe'consensusParams . _Just . Lens.from consensusParams
+          , initChainValidators = message ^.. PT.validators . traverse . Lens.from validatorUpdate
+          }
 
 --------------------------------------------------------------------------------
 -- Query
@@ -203,16 +206,17 @@ instance Wrapped Query where
           & PT.height .~ queryHeight
           & PT.codespace .~ queryCodespace
       f message =
-        Query { queryCode = message ^. PT.code
-              , queryLog = message ^. PT.log
-              , queryInfo = message ^. PT.info
-              , queryIndex = message ^. PT.index
-              , queryKey = message ^. PT.key
-              , queryValue = message ^. PT.value
-              , queryProof = message ^? PT.maybe'proof . _Just . Lens.from proof
-              , queryHeight = message ^. PT.height
-              , queryCodespace = message ^. PT.codespace
-              }
+        Query
+          { queryCode = message ^. PT.code
+          , queryLog = message ^. PT.log
+          , queryInfo = message ^. PT.info
+          , queryIndex = message ^. PT.index
+          , queryKey = message ^. PT.key
+          , queryValue = message ^. PT.value
+          , queryProof = message ^? PT.maybe'proof . _Just . Lens.from proof
+          , queryHeight = message ^. PT.height
+          , queryCodespace = message ^. PT.codespace
+          }
 
 --------------------------------------------------------------------------------
 -- BeginBlock
@@ -233,8 +237,9 @@ instance Wrapped BeginBlock where
         defMessage
           & PT.tags .~ beginBlockTags ^.. traverse . kVPair
       f message =
-        BeginBlock { beginBlockTags = message ^.. PT.tags . traverse . Lens.from kVPair
-                   }
+        BeginBlock
+          { beginBlockTags = message ^.. PT.tags . traverse . Lens.from kVPair
+          }
 
 --------------------------------------------------------------------------------
 -- CheckTx
@@ -276,15 +281,16 @@ instance Wrapped CheckTx where
           & PT.tags .~ checkTxTags ^.. traverse . kVPair
           & PT.codespace .~ checkTxCodespace
       f message =
-        CheckTx { checkTxCode = message ^. PT.code
-                , checkTxData = message ^. PT.data'
-                , checkTxLog = message ^. PT.log
-                , checkTxInfo = message ^. PT.info
-                , checkTxGasWanted = message ^. PT.gasWanted
-                , checkTxGasUsed = message ^. PT.gasUsed
-                , checkTxTags = message ^.. PT.tags . traverse . Lens.from kVPair
-                , checkTxCodespace = message ^. PT.codespace
-                }
+        CheckTx
+          { checkTxCode = message ^. PT.code
+          , checkTxData = message ^. PT.data'
+          , checkTxLog = message ^. PT.log
+          , checkTxInfo = message ^. PT.info
+          , checkTxGasWanted = message ^. PT.gasWanted
+          , checkTxGasUsed = message ^. PT.gasUsed
+          , checkTxTags = message ^.. PT.tags . traverse . Lens.from kVPair
+          , checkTxCodespace = message ^. PT.codespace
+          }
 
 --------------------------------------------------------------------------------
 -- DeliverTx
@@ -326,15 +332,16 @@ instance Wrapped DeliverTx where
           & PT.tags .~ deliverTxTags ^.. traverse . kVPair
           & PT.codespace .~ deliverTxCodespace
       f responseDeliverTx =
-        DeliverTx { deliverTxCode = responseDeliverTx ^. PT.code
-                  , deliverTxData = responseDeliverTx ^. PT.data'
-                  , deliverTxLog = responseDeliverTx ^. PT.log
-                  , deliverTxInfo = responseDeliverTx ^. PT.info
-                  , deliverTxGasWanted = responseDeliverTx ^. PT.gasWanted
-                  , deliverTxGasUsed = responseDeliverTx ^. PT.gasUsed
-                  , deliverTxTags = responseDeliverTx ^.. PT.tags . traverse . Lens.from kVPair
-                  , deliverTxCodespace = responseDeliverTx ^. PT.codespace
-                  }
+        DeliverTx
+          { deliverTxCode = responseDeliverTx ^. PT.code
+          , deliverTxData = responseDeliverTx ^. PT.data'
+          , deliverTxLog = responseDeliverTx ^. PT.log
+          , deliverTxInfo = responseDeliverTx ^. PT.info
+          , deliverTxGasWanted = responseDeliverTx ^. PT.gasWanted
+          , deliverTxGasUsed = responseDeliverTx ^. PT.gasUsed
+          , deliverTxTags = responseDeliverTx ^.. PT.tags . traverse . Lens.from kVPair
+          , deliverTxCodespace = responseDeliverTx ^. PT.codespace
+          }
 
 --------------------------------------------------------------------------------
 -- EndBlock
@@ -361,10 +368,11 @@ instance Wrapped EndBlock where
           & PT.maybe'consensusParamUpdates .~ endBlockConsensusParamUpdates ^? _Just . consensusParams
           & PT.tags .~ endBlockTags ^.. traverse . kVPair
       f message =
-        EndBlock { endBlockValidatorUpdates = message ^.. PT.validatorUpdates . traverse . Lens.from validatorUpdate
-                 , endBlockConsensusParamUpdates = message ^? PT.maybe'consensusParamUpdates . _Just . Lens.from consensusParams
-                 , endBlockTags = message ^.. PT.tags . traverse . Lens.from kVPair
-                 }
+        EndBlock
+          { endBlockValidatorUpdates = message ^.. PT.validatorUpdates . traverse . Lens.from validatorUpdate
+          , endBlockConsensusParamUpdates = message ^? PT.maybe'consensusParamUpdates . _Just . Lens.from consensusParams
+          , endBlockTags = message ^.. PT.tags . traverse . Lens.from kVPair
+          }
 
 --------------------------------------------------------------------------------
 -- Commit
@@ -385,8 +393,9 @@ instance Wrapped Commit where
         defMessage
           & PT.data' .~ commitData
       f message =
-        Commit { commitData = message ^. PT.data'
-               }
+        Commit
+          { commitData = message ^. PT.data'
+          }
 
 --------------------------------------------------------------------------------
 -- Exception

--- a/src/Network/ABCI/Types/Messages/Response.hs
+++ b/src/Network/ABCI/Types/Messages/Response.hs
@@ -52,6 +52,7 @@ data Response (m :: MessageType) :: * where
   ResponseCheckTx :: CheckTx -> Response 'MTCheckTx
   ResponseDeliverTx :: DeliverTx -> Response 'MTDeliverTx
   ResponseEndBlock :: EndBlock -> Response 'MTEndBlock
+  ResponseException :: forall (m :: MessageType) . Exception -> Response m
 
 --------------------------------------------------------------------------------
 -- Echo

--- a/src/Network/ABCI/Types/Messages/Response.hs
+++ b/src/Network/ABCI/Types/Messages/Response.hs
@@ -2,8 +2,7 @@ module Network.ABCI.Types.Messages.Response where
 
 import           Control.Lens                           (Iso', iso, traverse,
                                                          (&), (.~), (^.), (^..),
-                                                         (^?), _Just)
-import qualified Control.Lens                           as Lens
+                                                         (^?), _Just, from)
 import           Control.Lens.Wrapped                   (Wrapped(..))
 import           Data.ByteString                        (ByteString)
 import           Data.Int                               (Int64)
@@ -11,6 +10,7 @@ import           Data.ProtoLens.Message                 (Message (defMessage))
 import           Data.Text                              (Text)
 import           Data.Word                              (Word32, Word64)
 import           GHC.Generics                           (Generic)
+import           Network.ABCI.Types.Messages.Types      (MessageType(..))
 import           Network.ABCI.Types.Messages.FieldTypes (ConsensusParams,
                                                          Evidence, Header,
                                                          KVPair, LastCommitInfo,
@@ -24,6 +24,22 @@ import           Network.ABCI.Types.Messages.FieldTypes (ConsensusParams,
 import qualified Proto.Types                            as PT
 import qualified Proto.Types_Fields                     as PT
 
+
+--------------------------------------------------------------------------------
+-- Response
+--------------------------------------------------------------------------------
+
+data Response (m :: MessageType) :: * where
+  ResponseEcho :: Echo -> Response 'MTEcho
+  ResponseFlush :: Flush -> Response 'MTFlush
+  ResponseInfo :: Info -> Response 'MTInfo
+  ResponseSetOption :: SetOption -> Response 'MTSetOption
+  ResponseInitChain :: InitChain -> Response 'MTInitChain
+  ResponseQuery :: Query -> Response 'MTQuery
+  ResponseBeginBlock :: BeginBlock -> Response 'MTBeginBlock
+  ResponseCheckTx :: CheckTx -> Response 'MTCheckTx
+  ResponseDeliverTx :: DeliverTx -> Response 'MTDeliverTx
+  ResponseEndBlock :: EndBlock -> Response 'MTEndBlock
 
 --------------------------------------------------------------------------------
 -- Echo
@@ -155,8 +171,8 @@ instance Wrapped InitChain where
           & PT.validators .~ initChainValidators ^.. traverse . validatorUpdate
       f message =
         InitChain
-          { initChainConsensusParams = message ^? PT.maybe'consensusParams . _Just . Lens.from consensusParams
-          , initChainValidators = message ^.. PT.validators . traverse . Lens.from validatorUpdate
+          { initChainConsensusParams = message ^? PT.maybe'consensusParams . _Just . from consensusParams
+          , initChainValidators = message ^.. PT.validators . traverse . from validatorUpdate
           }
 
 --------------------------------------------------------------------------------
@@ -209,7 +225,7 @@ instance Wrapped Query where
           , queryIndex = message ^. PT.index
           , queryKey = message ^. PT.key
           , queryValue = message ^. PT.value
-          , queryProof = message ^? PT.maybe'proof . _Just . Lens.from proof
+          , queryProof = message ^? PT.maybe'proof . _Just . from proof
           , queryHeight = message ^. PT.height
           , queryCodespace = message ^. PT.codespace
           }
@@ -233,7 +249,7 @@ instance Wrapped BeginBlock where
           & PT.tags .~ beginBlockTags ^.. traverse . kVPair
       f message =
         BeginBlock
-          { beginBlockTags = message ^.. PT.tags . traverse . Lens.from kVPair
+          { beginBlockTags = message ^.. PT.tags . traverse . from kVPair
           }
 
 --------------------------------------------------------------------------------
@@ -282,7 +298,7 @@ instance Wrapped CheckTx where
           , checkTxInfo = message ^. PT.info
           , checkTxGasWanted = message ^. PT.gasWanted
           , checkTxGasUsed = message ^. PT.gasUsed
-          , checkTxTags = message ^.. PT.tags . traverse . Lens.from kVPair
+          , checkTxTags = message ^.. PT.tags . traverse . from kVPair
           , checkTxCodespace = message ^. PT.codespace
           }
 
@@ -332,7 +348,7 @@ instance Wrapped DeliverTx where
           , deliverTxInfo = responseDeliverTx ^. PT.info
           , deliverTxGasWanted = responseDeliverTx ^. PT.gasWanted
           , deliverTxGasUsed = responseDeliverTx ^. PT.gasUsed
-          , deliverTxTags = responseDeliverTx ^.. PT.tags . traverse . Lens.from kVPair
+          , deliverTxTags = responseDeliverTx ^.. PT.tags . traverse . from kVPair
           , deliverTxCodespace = responseDeliverTx ^. PT.codespace
           }
 
@@ -361,9 +377,9 @@ instance Wrapped EndBlock where
           & PT.tags .~ endBlockTags ^.. traverse . kVPair
       f message =
         EndBlock
-          { endBlockValidatorUpdates = message ^.. PT.validatorUpdates . traverse . Lens.from validatorUpdate
-          , endBlockConsensusParamUpdates = message ^? PT.maybe'consensusParamUpdates . _Just . Lens.from consensusParams
-          , endBlockTags = message ^.. PT.tags . traverse . Lens.from kVPair
+          { endBlockValidatorUpdates = message ^.. PT.validatorUpdates . traverse . from validatorUpdate
+          , endBlockConsensusParamUpdates = message ^? PT.maybe'consensusParamUpdates . _Just . from consensusParams
+          , endBlockTags = message ^.. PT.tags . traverse . from kVPair
           }
 
 --------------------------------------------------------------------------------

--- a/src/Network/ABCI/Types/Messages/Response.hs
+++ b/src/Network/ABCI/Types/Messages/Response.hs
@@ -58,9 +58,9 @@ data Response (m :: MessageType) :: * where
 --------------------------------------------------------------------------------
 
 data Echo = Echo
- { echoMessage :: Text
- -- ^ The input string
- } deriving (Eq, Show, Generic)
+  { echoMessage :: Text
+  -- ^ The input string
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped Echo where
   type Unwrapped Echo = PT.ResponseEcho
@@ -96,19 +96,18 @@ instance Wrapped Flush where
 -- Info
 --------------------------------------------------------------------------------
 
-data Info =
-  Info
-    { infoData             :: Text
-    -- ^ Some arbitrary information
-    , infoVersion          :: Text
-    -- ^ The application software semantic version
-    , infoAppVersion       :: Word64
-    -- ^ The application protocol version
-    , infoLastBlockHeight  :: Int64
-    -- ^  Latest block for which the app has called Commit
-    , infoLastBlockAppHash :: ByteString
-    -- ^  Latest result of Commit
-    } deriving (Eq, Show, Generic)
+data Info = Info
+  { infoData             :: Text
+  -- ^ Some arbitrary information
+  , infoVersion          :: Text
+  -- ^ The application software semantic version
+  , infoAppVersion       :: Word64
+  -- ^ The application protocol version
+  , infoLastBlockHeight  :: Int64
+  -- ^  Latest block for which the app has called Commit
+  , infoLastBlockAppHash :: ByteString
+  -- ^  Latest result of Commit
+  } deriving (Eq, Show, Generic)
 
 instance Wrapped Info where
   type Unwrapped Info = PT.ResponseInfo
@@ -424,13 +423,15 @@ data Exception = Exception
   { exceptionError :: Text
   } deriving (Eq, Show, Generic)
 
-exception :: Iso' Exception PT.ResponseException
-exception = iso t f
-  where
-    t Exception{..} =
-      defMessage
-        & PT.error .~ exceptionError
-    f responseException =
-      Exception
-        { exceptionError = responseException ^. PT.error
-        }
+instance Wrapped Exception where
+  type Unwrapped Exception = PT.ResponseException
+
+  _Wrapped' = iso t f
+    where
+      t Exception{..} =
+        defMessage
+          & PT.error .~ exceptionError
+      f responseException =
+        Exception
+          { exceptionError = responseException ^. PT.error
+          }

--- a/src/Network/ABCI/Types/Messages/Types.hs
+++ b/src/Network/ABCI/Types/Messages/Types.hs
@@ -1,0 +1,15 @@
+module Network.ABCI.Types.Messages.Types where
+
+-- | Used to parametrize Request and Respone types
+data MessageType =
+    MTEcho
+  | MTFlush
+  | MTInfo
+  | MTSetOption
+  | MTInitChain
+  | MTQuery
+  | MTBeginBlock
+  | MTCheckTx
+  | MTDeliverTx
+  | MTEndBlock
+  | MTCommit


### PR DESCRIPTION
- fixes #9 
- makes the style conform to #10 
- simplify variable naming to facilitate copy/paste
- get rid of qualified import of `Lens.from`