### PR TITLE
Charlescrain/issue 8 correct protobufs

### DIFF
--- a/protos/types.proto
+++ b/protos/types.proto
@@ -12,14 +12,14 @@ import "vendored/tendermint/tendermint/crypto/merkle/merkle.proto";
 // NOTE: When using custom types, mind the warnings.
 // https://github.com/gogo/protobuf/blob/master/custom_types.md#warnings-and-issues
 
-//option (gogoproto.marshaler_all) = true;
-//option (gogoproto.unmarshaler_all) = true;
-//option (gogoproto.sizer_all) = true;
-//option (gogoproto.goproto_registration) = true;
-//// Generate tests
-//option (gogoproto.populate_all) = true;
-//option (gogoproto.equal_all) = true;
-//option (gogoproto.testgen_all) = true;
+option (gogoproto.marshaler_all) = true;
+option (gogoproto.unmarshaler_all) = true;
+option (gogoproto.sizer_all) = true;
+option (gogoproto.goproto_registration) = true;
+// Generate tests
+option (gogoproto.populate_all) = true;
+option (gogoproto.equal_all) = true;
+option (gogoproto.testgen_all) = true;
 
 //----------------------------------------
 // Request types
@@ -165,7 +165,7 @@ message ResponseQuery {
 }
 
 message ResponseBeginBlock {
-  repeated common.KVPair tags = 1 [(gogoproto.nullable)=false, (gogoproto.jsontag)="tags,omitempty"];
+  repeated Event events = 1 [(gogoproto.nullable)=false, (gogoproto.jsontag)="events,omitempty"];
 }
 
 message ResponseCheckTx {
@@ -175,7 +175,7 @@ message ResponseCheckTx {
   string info = 4; // nondeterministic
   int64 gas_wanted  = 5;
   int64 gas_used = 6;
-  repeated common.KVPair tags = 7 [(gogoproto.nullable)=false, (gogoproto.jsontag)="tags,omitempty"];
+  repeated Event events = 7 [(gogoproto.nullable)=false, (gogoproto.jsontag)="events,omitempty"];
   string codespace = 8;
 }
 
@@ -186,14 +186,14 @@ message ResponseDeliverTx {
   string info = 4; // nondeterministic
   int64 gas_wanted = 5;
   int64 gas_used = 6;
-  repeated common.KVPair tags = 7 [(gogoproto.nullable)=false, (gogoproto.jsontag)="tags,omitempty"];
+  repeated Event events = 7 [(gogoproto.nullable)=false, (gogoproto.jsontag)="events,omitempty"];
   string codespace = 8;
 }
 
 message ResponseEndBlock {
   repeated ValidatorUpdate validator_updates = 1 [(gogoproto.nullable)=false];
   ConsensusParams consensus_param_updates = 2;
-  repeated common.KVPair tags = 3 [(gogoproto.nullable)=false, (gogoproto.jsontag)="tags,omitempty"];
+  repeated Event events = 3 [(gogoproto.nullable)=false, (gogoproto.jsontag)="events,omitempty"];
 }
 
 message ResponseCommit {
@@ -207,13 +207,13 @@ message ResponseCommit {
 // ConsensusParams contains all consensus-relevant parameters
 // that can be adjusted by the abci app
 message ConsensusParams {
-  BlockSizeParams block_size = 1;
+  BlockParams block = 1;
   EvidenceParams evidence = 2;
   ValidatorParams validator = 3;
 }
 
-// BlockSize contains limits on the block size.
-message BlockSizeParams {
+// BlockParams contains limits on the block size.
+message BlockParams {
   // Note: must be greater than 0
   int64 max_bytes = 1;
   // Note: must be greater or equal to -1
@@ -234,6 +234,11 @@ message ValidatorParams {
 message LastCommitInfo {
   int32 round = 1;
   repeated VoteInfo votes = 2 [(gogoproto.nullable)=false];
+}
+
+message Event {
+  string type = 1;
+  repeated common.KVPair attributes = 2 [(gogoproto.nullable)=false, (gogoproto.jsontag)="attributes,omitempty"];
 }
 
 //----------------------------------------

--- a/src/Network/ABCI/Types/Messages/Response.hs
+++ b/src/Network/ABCI/Types/Messages/Response.hs
@@ -250,7 +250,7 @@ instance Wrapped Query where
 
 data BeginBlock = BeginBlock
   { beginBlockEvents :: [Event]
-  -- ^ Key-Value tags for filtering and indexing
+  -- ^ Beginning block events
   } deriving (Eq, Show, Generic)
 
 instance Wrapped BeginBlock where
@@ -284,7 +284,7 @@ data CheckTx = CheckTx
   , checkTxGasUsed   :: Int64
   -- ^ Amount of gas consumed by transaction.
   , checkTxEvents    :: [Event]
-  -- ^ Key-Value events for filtering and indexing transactions (eg. by account).
+  -- ^ Events
   , checkTxCodespace :: Text
   -- ^ Namespace for the Code.
   } deriving (Eq, Show, Generic)
@@ -334,7 +334,7 @@ data DeliverTx = DeliverTx
   , deliverTxGasUsed   :: Int64
   -- ^ Amount of gas consumed by transaction.
   , deliverTxEvents      :: [Event]
-  -- ^  Key-Value events for filtering and indexing transactions (eg. by account).
+  -- ^ Events
   , deliverTxCodespace :: Text
   -- ^ Namespace for the Code.
   } deriving (Eq, Show, Generic)
@@ -376,7 +376,7 @@ data EndBlock = EndBlock
   , endBlockConsensusParamUpdates :: Maybe ConsensusParams
   -- ^ Changes to consensus-critical time, size, and other parameters.
   , endBlockEvents                  :: [Event]
-  -- ^ Key-Value events for filtering and indexing
+  -- ^ Events
   } deriving (Eq, Show, Generic)
 
 instance Wrapped EndBlock where

--- a/src/Network/ABCI/Types/Messages/Response.hs
+++ b/src/Network/ABCI/Types/Messages/Response.hs
@@ -30,8 +30,8 @@ import           Data.ProtoLens.Message                 (Message (defMessage))
 import           Data.Text                              (Text)
 import           Data.Word                              (Word32, Word64)
 import           GHC.Generics                           (Generic)
-import           Network.ABCI.Types.Messages.FieldTypes (ConsensusParams,
-                                                         KVPair, Proof,
+import           Network.ABCI.Types.Messages.FieldTypes (ConsensusParams, Event,
+                                                         Proof,
                                                          ValidatorUpdate)
 import           Network.ABCI.Types.Messages.Types      (MessageType (..))
 import qualified Proto.Types                            as PT
@@ -249,7 +249,7 @@ instance Wrapped Query where
 --------------------------------------------------------------------------------
 
 data BeginBlock = BeginBlock
-  { beginBlockTags :: [KVPair]
+  { beginBlockEvents :: [Event]
   -- ^ Key-Value tags for filtering and indexing
   } deriving (Eq, Show, Generic)
 
@@ -260,10 +260,10 @@ instance Wrapped BeginBlock where
     where
       t BeginBlock{..} =
         defMessage
-          & PT.tags .~ beginBlockTags ^.. traverse . _Wrapped'
+          & PT.events .~ beginBlockEvents ^.. traverse . _Wrapped'
       f message =
         BeginBlock
-          { beginBlockTags = message ^.. PT.tags . traverse . _Unwrapped'
+          { beginBlockEvents = message ^.. PT.events . traverse . _Unwrapped'
           }
 
 --------------------------------------------------------------------------------
@@ -283,8 +283,8 @@ data CheckTx = CheckTx
   -- ^ Amount of gas requested for transaction.
   , checkTxGasUsed   :: Int64
   -- ^ Amount of gas consumed by transaction.
-  , checkTxTags      :: [KVPair]
-  -- ^ Key-Value tags for filtering and indexing transactions (eg. by account).
+  , checkTxEvents    :: [Event]
+  -- ^ Key-Value events for filtering and indexing transactions (eg. by account).
   , checkTxCodespace :: Text
   -- ^ Namespace for the Code.
   } deriving (Eq, Show, Generic)
@@ -302,7 +302,7 @@ instance Wrapped CheckTx where
           & PT.info .~ checkTxInfo
           & PT.gasWanted .~ checkTxGasWanted
           & PT.gasUsed .~ checkTxGasUsed
-          & PT.tags .~ checkTxTags ^.. traverse . _Wrapped'
+          & PT.events .~ checkTxEvents ^.. traverse . _Wrapped'
           & PT.codespace .~ checkTxCodespace
       f message =
         CheckTx
@@ -312,7 +312,7 @@ instance Wrapped CheckTx where
           , checkTxInfo = message ^. PT.info
           , checkTxGasWanted = message ^. PT.gasWanted
           , checkTxGasUsed = message ^. PT.gasUsed
-          , checkTxTags = message ^.. PT.tags . traverse . _Unwrapped'
+          , checkTxEvents = message ^.. PT.events . traverse . _Unwrapped'
           , checkTxCodespace = message ^. PT.codespace
           }
 
@@ -333,8 +333,8 @@ data DeliverTx = DeliverTx
   -- ^ Amount of gas requested for transaction.
   , deliverTxGasUsed   :: Int64
   -- ^ Amount of gas consumed by transaction.
-  , deliverTxTags      :: [KVPair]
-  -- ^  Key-Value tags for filtering and indexing transactions (eg. by account).
+  , deliverTxEvents      :: [Event]
+  -- ^  Key-Value events for filtering and indexing transactions (eg. by account).
   , deliverTxCodespace :: Text
   -- ^ Namespace for the Code.
   } deriving (Eq, Show, Generic)
@@ -352,7 +352,7 @@ instance Wrapped DeliverTx where
           & PT.info .~ deliverTxInfo
           & PT.gasWanted .~ deliverTxGasWanted
           & PT.gasUsed .~ deliverTxGasUsed
-          & PT.tags .~ deliverTxTags ^.. traverse . _Wrapped'
+          & PT.events .~ deliverTxEvents ^.. traverse . _Wrapped'
           & PT.codespace .~ deliverTxCodespace
       f responseDeliverTx =
         DeliverTx
@@ -362,7 +362,7 @@ instance Wrapped DeliverTx where
           , deliverTxInfo = responseDeliverTx ^. PT.info
           , deliverTxGasWanted = responseDeliverTx ^. PT.gasWanted
           , deliverTxGasUsed = responseDeliverTx ^. PT.gasUsed
-          , deliverTxTags = responseDeliverTx ^.. PT.tags . traverse . _Unwrapped'
+          , deliverTxEvents = responseDeliverTx ^.. PT.events . traverse . _Unwrapped'
           , deliverTxCodespace = responseDeliverTx ^. PT.codespace
           }
 
@@ -375,8 +375,8 @@ data EndBlock = EndBlock
   -- ^ Changes to validator set (set voting power to 0 to remove).
   , endBlockConsensusParamUpdates :: Maybe ConsensusParams
   -- ^ Changes to consensus-critical time, size, and other parameters.
-  , endBlockTags                  :: [KVPair]
-  -- ^ Key-Value tags for filtering and indexing
+  , endBlockEvents                  :: [Event]
+  -- ^ Key-Value events for filtering and indexing
   } deriving (Eq, Show, Generic)
 
 instance Wrapped EndBlock where
@@ -388,12 +388,12 @@ instance Wrapped EndBlock where
         defMessage
           & PT.validatorUpdates .~ endBlockValidatorUpdates ^.. traverse . _Wrapped'
           & PT.maybe'consensusParamUpdates .~ endBlockConsensusParamUpdates ^? _Just . _Wrapped'
-          & PT.tags .~ endBlockTags ^.. traverse . _Wrapped'
+          & PT.events .~ endBlockEvents ^.. traverse . _Wrapped'
       f message =
         EndBlock
           { endBlockValidatorUpdates = message ^.. PT.validatorUpdates . traverse . _Unwrapped'
           , endBlockConsensusParamUpdates = message ^? PT.maybe'consensusParamUpdates . _Just . _Unwrapped'
-          , endBlockTags = message ^.. PT.tags . traverse . _Unwrapped'
+          , endBlockEvents = message ^.. PT.events . traverse . _Unwrapped'
           }
 
 --------------------------------------------------------------------------------

--- a/test/Network/ABCI/Test/Types/Messages/Instances.hs
+++ b/test/Network/ABCI/Test/Types/Messages/Instances.hs
@@ -13,7 +13,7 @@ instance Arbitrary FieldTypes.Timestamp where
     FieldTypes.Timestamp ts <- genericArbitrary
     pure $ FieldTypes.mkTimestamp $ abs ts
 
-instance Arbitrary FieldTypes.BlockSizeParams where arbitrary = genericArbitrary
+instance Arbitrary FieldTypes.BlockParams where arbitrary = genericArbitrary
 instance Arbitrary FieldTypes.EvidenceParams where arbitrary = genericArbitrary
 instance Arbitrary FieldTypes.ValidatorParams where arbitrary = genericArbitrary
 instance Arbitrary FieldTypes.ConsensusParams where arbitrary = genericArbitrary
@@ -30,6 +30,7 @@ instance Arbitrary FieldTypes.Evidence where arbitrary = genericArbitrary
 instance Arbitrary FieldTypes.KVPair where arbitrary = genericArbitrary
 instance Arbitrary FieldTypes.Proof where arbitrary = genericArbitrary
 instance Arbitrary FieldTypes.ProofOp where arbitrary = genericArbitrary
+instance Arbitrary FieldTypes.Event where arbitrary = genericArbitrary
 
 instance Arbitrary Request.Echo where arbitrary = genericArbitrary
 instance Arbitrary Request.Flush where arbitrary = genericArbitrary

--- a/test/Network/ABCI/Test/Types/MessagesSpec.hs
+++ b/test/Network/ABCI/Test/Types/MessagesSpec.hs
@@ -147,7 +147,7 @@ spec = do
     isoCheck (Proxy :: Proxy Response.Exception) "exception"
   describe "FieldTypes" $ do
     isoCheck' (Proxy :: Proxy FT.Timestamp) "Timestamp" id scrubTimestamp
-    isoCheck (Proxy :: Proxy FT.BlockSizeParams) "BlockSizeParams"
+    isoCheck (Proxy :: Proxy FT.BlockParams) "BlockParams"
     isoCheck (Proxy :: Proxy FT.EvidenceParams) "EvidenceParams"
     isoCheck (Proxy :: Proxy FT.ValidatorParams) "ValidatorParams"
     isoCheck (Proxy :: Proxy FT.ConsensusParams) "ConsensusParam"
@@ -164,3 +164,4 @@ spec = do
     isoCheck (Proxy :: Proxy FT.KVPair) "KVPair"
     isoCheck (Proxy :: Proxy FT.Proof) "Proof"
     isoCheck (Proxy :: Proxy FT.ProofOp) "ProofOp"
+    isoCheck (Proxy :: Proxy FT.Event) "Event"


### PR DESCRIPTION
## Changes

* updated `types.proto` file to use https://github.com/tendermint/tendermint/blob/v0.32.0/abci/types/types.proto
* Added new `data Event` in `FieldTypes.hs` 
* renamed `data BlockSizeParams` -> `data BlockParams`
* Added `isoCheck` tests for `Event`

## Note 

The previous version of `types.proto` file had

```proto
option (gogoproto.marshaler_all) = true;
option (gogoproto.unmarshaler_all) = true;
option (gogoproto.sizer_all) = true;
option (gogoproto.goproto_registration) = true;
```

commented out, wasn't sure if we wanted this or not. 