### PR TITLE
Example app tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ script:
 # When branch is `master` we run `haskell-stylish` and fail if git working directory becomes dirty
 - if [ "$TRAVIS_BRANCH" == "master" ]; then make stylish && git diff-index --quiet HEAD; fi
 
-- make test
+- make test-libraries

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,4 @@ script:
 - if [ "$TRAVIS_BRANCH" == "master" ]; then make stylish && git diff-index --quiet HEAD; fi
 
 - make test-libraries
+- make test-simple-storage-handlers

--- a/Makefile
+++ b/Makefile
@@ -6,23 +6,46 @@ export
 # This is useful for copying example app binaries built on a linux machine rather than building in docker
 SIMPLE_STORAGE_BINARY := $(shell stack exec -- which simple-storage)
 
-build-docs-local: ## Build the haddocks documentation for just this project (no dependencies)
-	stack haddock --no-haddock-deps
-
-install: ## Runs stack install to compile library and counter example app
-	stack install
+#####################
+# Linting and Styling
+#####################
 
 hlint: ## Run hlint on all haskell projects
 	stack exec hlint -- -h .hlint.yaml hs-abci-server hs-abci-example hs-tendermint-client hs-abci-extra
 
-test: install ## Run the haskell test suite for all haskell projects
-	stack test
+stylish: ## Run stylish-haskell over all haskell projects
+	find ./hs-abci-types ./hs-abci-extra ./hs-tendermint-client ./hs-abci-example ./hs-abci-server -name "*.hs" | xargs stack exec stylish-haskell -- -c ./.stylish_haskell.yaml -i
 
-deploy-simple-storage: install ## run the simple storage docker network
+###################
+# DOCS
+###################
+
+build-docs-local: ## Build the haddocks documentation for just this project (no dependencies)
+	stack haddock --no-haddock-deps
+
+#####################
+# Core Libraries
+#####################
+
+install: ## Runs stack install to compile library and counter example app
+	stack install
+
+test-libraries: install ## Run the haskell test suite for all haskell libraries
+	stack test hs-abci-types hs-abci-server
+
+
+#####################
+# Example Application
+#####################
+
+deploy-simple-storage-docker: install ## run the simple storage docker network
 	docker-compose -f hs-abci-example/docker-compose.yaml up --build -d
+
+deploy-simple-storage-local: install ## run the simple storage locally
+	stack exec simple-storage
 
 run-simple-storage: install ## Run the example simple-storage app
 	stack exec -- simple-storage
 
-stylish: ## Run stylish-haskell over all haskell projects
-	find ./hs-abci-types ./hs-abci-extra ./hs-tendermint-client ./hs-abci-example ./hs-abci-server -name "*.hs" | xargs stack exec stylish-haskell -- -c ./.stylish_haskell.yaml -i
+test-simple-storage: install ## Run the test suite for the example application
+	stack test hs-abci-example

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,5 @@ deploy-simple-storage-docker: install ## run the simple storage docker network
 deploy-simple-storage-local: install ## run the simple storage locally
 	stack exec simple-storage
 
-run-simple-storage: install ## Run the example simple-storage app
-	stack exec -- simple-storage
-
 test-simple-storage: install ## Run the test suite for the example application
 	stack test hs-abci-example

--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,6 @@ deploy-simple-storage-local: install ## run the simple storage locally
 
 test-simple-storage: install ## Run the test suite for the example application
 	stack test hs-abci-example
+
+test-simple-storage-handlers: install ## Run the haskell test suite the example application handlers
+	stack test hs-abci-example --test-arguments "-m handlers"

--- a/hs-abci-example/README.md
+++ b/hs-abci-example/README.md
@@ -8,12 +8,26 @@ allows users to update and query the count.
 There is a `docker-compose.yaml` file in this directory. If you use the `make` command from the project root
 
 ```bash
-> make deploy-simple-storage
+> make deploy-simple-storage-docker
 ```
 
 it will build an image for simple-storage and launch it in a docker network
 with a tendermint-core node. The port for simple-storage is not exposed outside of the docker network --
 of you would like to submit transactions or query state you must do it using the tendermint RPC.
+
+## Running Locally
+Assuming you have a [Tendermint v0.32.2 binary](https://github.com/tendermint/tendermint/releases/tag/v0.32.2) in your path, you can start a tendermint core node with
+
+```bash
+> tendermint init
+> tendermint node --consensus.create_empty_blocks=false
+```
+
+The `--consensus.create_empty_blocks=false` flag is helpful for keeping the logs from being polluted with empty blocks. You can then then start the example application using
+
+```bash
+> make deploy-simple-storage-local
+```
 
 ## Application Messages
 The application uses a protobuf file to define its [transaction messages](https://github.com/f-o-a-m/hs-abci/blob/master/hs-abci-example/protos/simple-storage/messages.proto). Thus if you would like to post transactions to this application via RPC, you will need to first consume

--- a/hs-abci-example/package.yaml
+++ b/hs-abci-example/package.yaml
@@ -107,3 +107,4 @@ tests:
       - hs-abci-types
       - hs-tendermint-client
       - hspec
+      - QuickCheck

--- a/hs-abci-example/package.yaml
+++ b/hs-abci-example/package.yaml
@@ -84,3 +84,20 @@ executables:
     - -Wall
     dependencies:
     - hs-abci-example
+
+tests:
+  hs-abci-example-e2e:
+    main:                Spec.hs
+    source-dirs:         test
+    other-modules:
+    - SimpleStorage.Test.E2ESpec
+    ghc-options:
+    - -Werror
+    - -Wall
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+
+    dependencies:
+      - hspec
+      - hs-abci-example

--- a/hs-abci-example/package.yaml
+++ b/hs-abci-example/package.yaml
@@ -92,6 +92,7 @@ tests:
     source-dirs:         test
     other-modules:
     - SimpleStorage.Test.E2ESpec
+    - SimpleStorage.Test.HandlersSpec
     ghc-options:
     - -Werror
     - -Wall

--- a/hs-abci-example/package.yaml
+++ b/hs-abci-example/package.yaml
@@ -100,4 +100,5 @@ tests:
 
     dependencies:
       - hspec
+      - hs-tendermint-client
       - hs-abci-example

--- a/hs-abci-example/package.yaml
+++ b/hs-abci-example/package.yaml
@@ -29,22 +29,23 @@ default-extensions:
 
 
 dependencies:
+- avl-auth
 - base >= 4.7 && < 5
 - binary
 - bytestring
 - containers
 - cryptonite
 - data-default-class
+- hs-abci-extra
 - hs-abci-server
 - hs-abci-types
-- hs-abci-extra
 - lens
-- avl-auth
 - memory
 - mtl
 - proto-lens
 - proto-lens-runtime
 - stm
+- string-conversions
 - text
 
 custom-setup:
@@ -99,6 +100,9 @@ tests:
     - -with-rtsopts=-N
 
     dependencies:
-      - hspec
-      - hs-tendermint-client
+      - aeson
+      - aeson-pretty
       - hs-abci-example
+      - hs-abci-types
+      - hs-tendermint-client
+      - hspec

--- a/hs-abci-example/test/SimpleStorage/Test/E2ESpec.hs
+++ b/hs-abci-example/test/SimpleStorage/Test/E2ESpec.hs
@@ -14,16 +14,16 @@ import qualified Network.Tendermint.Client            as RPC
 import           Test.Hspec
 
 
-
 spec :: Spec
 spec = do
-  describe "SimpleStorage E2E" $ do
+  describe "SimpleStorage E2E - via hs-tendermint-client" $ do
 
---    it "Can query /health to make sure the node is alive" $ do
---      resp <- runRPC RPC.health
---      resp `shouldBe` RPC.ResultHealth
+    it "Can query /health to make sure the node is alive" $ do
+      resp <- runRPC RPC.health
+      resp `shouldBe` RPC.ResultHealth
 
     it "Can query the initial count and make sure it's 0" $ do
+      pendingWith "Pending hs-tendermint-client resolution."
       let queryReq =
             def { RPC.requestABCIQueryPath = Just "count"
                 }

--- a/hs-abci-example/test/SimpleStorage/Test/E2ESpec.hs
+++ b/hs-abci-example/test/SimpleStorage/Test/E2ESpec.hs
@@ -1,0 +1,9 @@
+module SimpleStorage.Test.E2ESpec where
+
+import           Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "SimpleStorage E2E" $ do
+    it "Can query the initial count" $
+      pending

--- a/hs-abci-example/test/SimpleStorage/Test/E2ESpec.hs
+++ b/hs-abci-example/test/SimpleStorage/Test/E2ESpec.hs
@@ -1,17 +1,49 @@
 module SimpleStorage.Test.E2ESpec where
 
-import qualified Network.Tendermint.Client as RPC
+import           Control.Lens                         (to, (^.))
+import           Data.Aeson                           (ToJSON)
+import           Data.Aeson.Encode.Pretty             (encodePretty)
+import           Data.Binary                          (decode, encode)
+import qualified Data.ByteArray.HexString             as Hex
+import qualified Data.ByteString.Lazy                 as LBS
+import           Data.Default.Class                   (def)
+import           Data.Int                             (Int32)
+import           Data.String.Conversions              (cs)
+import qualified Network.ABCI.Types.Messages.Response as Resp
+import qualified Network.Tendermint.Client            as RPC
 import           Test.Hspec
+
+
 
 spec :: Spec
 spec = do
   describe "SimpleStorage E2E" $ do
-    it "Can query /health to make sure the node is alive" $ do
-      resp <- runRPC RPC.health
-      resp `shouldBe` RPC.ResultHealth
+
+--    it "Can query /health to make sure the node is alive" $ do
+--      resp <- runRPC RPC.health
+--      resp `shouldBe` RPC.ResultHealth
+
+    it "Can query the initial count and make sure it's 0" $ do
+      let queryReq =
+            def { RPC.requestABCIQueryPath = Just "count"
+                }
+      queryResp <- fmap RPC.resultABCIQueryResponse . runRPC $
+        RPC.abciQuery queryReq
+      let foundCount = queryResp ^. Resp._queryValue . to decodeCount
+      foundCount `shouldBe` 0
+
+encodeCount :: Int32 -> Hex.HexString
+encodeCount = Hex.fromBytes . LBS.toStrict . encode
+
+decodeCount :: Hex.HexString -> Int32
+decodeCount =  decode . LBS.fromStrict . Hex.toBytes
 
 runRPC :: forall a. RPC.TendermintM a -> IO a
 runRPC = RPC.runTendermintM rpcConfig
   where
     rpcConfig :: RPC.Config
-    rpcConfig = RPC.defaultConfig "localhost" 26657
+    rpcConfig =
+      let RPC.Config baseReq _ _ = RPC.defaultConfig "localhost" 26657
+          prettyPrint :: forall b. ToJSON b => String -> b -> IO ()
+          prettyPrint prefix a = putStrLn $ prefix <> "\n" <> (cs . encodePretty $ a)
+      in RPC.Config baseReq (prettyPrint "RPC Request") (prettyPrint "RPC Response")

--- a/hs-abci-example/test/SimpleStorage/Test/E2ESpec.hs
+++ b/hs-abci-example/test/SimpleStorage/Test/E2ESpec.hs
@@ -1,9 +1,17 @@
 module SimpleStorage.Test.E2ESpec where
 
+import qualified Network.Tendermint.Client as RPC
 import           Test.Hspec
 
 spec :: Spec
 spec = do
   describe "SimpleStorage E2E" $ do
-    it "Can query the initial count" $
-      pending
+    it "Can query /health to make sure the node is alive" $ do
+      resp <- runRPC RPC.health
+      resp `shouldBe` RPC.ResultHealth
+
+runRPC :: forall a. RPC.TendermintM a -> IO a
+runRPC = RPC.runTendermintM rpcConfig
+  where
+    rpcConfig :: RPC.Config
+    rpcConfig = RPC.defaultConfig "localhost" 26657

--- a/hs-abci-example/test/SimpleStorage/Test/HandlersSpec.hs
+++ b/hs-abci-example/test/SimpleStorage/Test/HandlersSpec.hs
@@ -1,0 +1,35 @@
+module SimpleStorage.Test.HandlersSpec where
+
+import           Control.Lens                         (to, (^.))
+import           Control.Lens.Wrapped                 (_Unwrapped')
+import           Data.Binary                          (decode, encode)
+import qualified Data.ByteArray.HexString             as Hex
+import qualified Data.ByteString.Lazy                 as LBS
+import           Data.Int                             (Int32)
+import           Data.ProtoLens                       (defMessage)
+import           Network.ABCI.Server.App              (Request (..),
+                                                       Response (..))
+import qualified Network.ABCI.Types.Messages.Response as Resp
+import           SimpleStorage.Application            (makeAppConfig,
+                                                       transformHandler)
+import           SimpleStorage.Handlers               (queryH)
+import           Test.Hspec
+
+
+spec :: Spec
+spec = beforeAll makeAppConfig $ do
+  describe "SimpleStorage E2E - via handlers" $ do
+    it "Can query the initial count and make sure it's 0" $ \cfg -> do
+      let handle = transformHandler cfg . queryH
+      (ResponseQuery queryResp) <- handle (RequestQuery $ defMessage ^. _Unwrapped')
+      print queryResp
+      let foundCount = queryResp ^. Resp._queryValue . to decodeCount
+      foundCount `shouldBe` 0
+
+encodeCount :: Int32 -> Hex.HexString
+encodeCount 0 = "0x"
+encodeCount c = Hex.fromBytes . LBS.toStrict . encode $ c
+
+decodeCount :: Hex.HexString -> Int32
+decodeCount "0x" = 0
+decodeCount hs   =  decode . LBS.fromStrict . Hex.toBytes $ hs

--- a/hs-abci-example/test/SimpleStorage/Test/HandlersSpec.hs
+++ b/hs-abci-example/test/SimpleStorage/Test/HandlersSpec.hs
@@ -1,19 +1,24 @@
 module SimpleStorage.Test.HandlersSpec where
 
-import           Control.Lens                         (to, (^.))
-import           Control.Lens.Wrapped                 (_Unwrapped')
+import           Control.Lens                         (to, (&), (.~), (^.))
+import           Control.Lens.Wrapped                 (_Unwrapped', _Wrapped')
 import           Data.Binary                          (decode, encode)
 import qualified Data.ByteArray.HexString             as Hex
 import qualified Data.ByteString.Lazy                 as LBS
 import           Data.Int                             (Int32)
 import           Data.ProtoLens                       (defMessage)
+import           Data.ProtoLens.Encoding              (encodeMessage)
+import           Data.Text                            (pack)
 import           Network.ABCI.Server.App              (Request (..),
                                                        Response (..))
+import qualified Network.ABCI.Types.Messages.Request  as Req
 import qualified Network.ABCI.Types.Messages.Response as Resp
 import           SimpleStorage.Application            (makeAppConfig,
                                                        transformHandler)
-import           SimpleStorage.Handlers               (queryH)
+import           SimpleStorage.Handlers               (deliverTxH, queryH)
+import           SimpleStorage.Types                  (UpdateCountTx (..))
 import           Test.Hspec
+import           Test.QuickCheck
 
 
 spec :: Spec
@@ -21,10 +26,32 @@ spec = beforeAll makeAppConfig $ do
   describe "SimpleStorage E2E - via handlers" $ do
     it "Can query the initial count and make sure it's 0" $ \cfg -> do
       let handle = transformHandler cfg . queryH
-      (ResponseQuery queryResp) <- handle (RequestQuery $ defMessage ^. _Unwrapped')
-      print queryResp
+      (ResponseQuery queryResp) <- handle
+        (RequestQuery $ defMessage ^. _Unwrapped' & Req._queryPath .~ "count")
       let foundCount = queryResp ^. Resp._queryValue . to decodeCount
       foundCount `shouldBe` 0
+    it "Can update count and make sure it's increments" $ \cfg -> do
+      genUsername <- pack . getPrintableString <$> generate arbitrary
+      genCount    <- abs <$> generate arbitrary
+      let
+        handleDeliver = transformHandler cfg . deliverTxH
+        handleQuery = transformHandler cfg . queryH
+        updateTx = (defMessage ^. _Unwrapped') { updateCountTxUsername = genUsername
+                                               , updateCountTxCount = genCount
+                                               }
+        encodedUpdateTx = Hex.fromBytes $ encodeMessage (updateTx ^. _Wrapped')
+      (ResponseDeliverTx deliverResp) <- handleDeliver
+        (  RequestDeliverTx
+        $  defMessage
+        ^. _Unwrapped'
+        &  Req._deliverTxTx
+        .~ encodedUpdateTx
+        )
+      (deliverResp ^. Resp._deliverTxCode) `shouldBe` 0
+      (ResponseQuery queryResp) <- handleQuery
+        (RequestQuery $ defMessage ^. _Unwrapped' & Req._queryPath .~ "count")
+      let foundCount = queryResp ^. Resp._queryValue . to decodeCount
+      foundCount `shouldBe` genCount
 
 encodeCount :: Int32 -> Hex.HexString
 encodeCount 0 = "0x"
@@ -32,4 +59,4 @@ encodeCount c = Hex.fromBytes . LBS.toStrict . encode $ c
 
 decodeCount :: Hex.HexString -> Int32
 decodeCount "0x" = 0
-decodeCount hs   =  decode . LBS.fromStrict . Hex.toBytes $ hs
+decodeCount hs   = decode . LBS.fromStrict . Hex.toBytes $ hs

--- a/hs-abci-example/test/Spec.hs
+++ b/hs-abci-example/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/hs-abci-types/src/Data/ByteArray/HexString.hs
+++ b/hs-abci-types/src/Data/ByteArray/HexString.hs
@@ -23,7 +23,7 @@ newtype HexString = HexString { unHexString :: ByteString }
   deriving (Eq, Ord, Semigroup, Monoid, ByteArrayAccess, ByteArray)
 
 instance Show HexString where
-    show = ("HexString " ++) . show . toText
+    show = ("HexString " ++) . show . format
 
 instance IsString HexString where
     fromString = hexString' . fromString
@@ -57,4 +57,8 @@ toBytes = convert . unHexString
 
 -- | Access to a 'Text' representation of the 'HexString'
 toText :: HexString -> Text
-toText = ("0x" <>) . decodeUtf8 . convertToBase Base16 . unHexString
+toText = decodeUtf8 . convertToBase Base16 . unHexString
+
+-- | Access to a 'Text' representation of the 'HexString'
+format :: HexString -> Text
+format a = "0x" <> toText a

--- a/hs-tendermint-client/package.yaml
+++ b/hs-tendermint-client/package.yaml
@@ -29,6 +29,7 @@ default-extensions:
 - ScopedTypeVariables
 - FlexibleInstances
 - OverloadedStrings
+- GeneralizedNewtypeDeriving
 
 
 dependencies:

--- a/hs-tendermint-client/package.yaml
+++ b/hs-tendermint-client/package.yaml
@@ -32,20 +32,21 @@ default-extensions:
 
 
 dependencies:
-- base >= 4.7 && < 5
-- bytestring
-- base16-bytestring
-- text
-- time
-- exceptions
-- mtl
-- http-conduit
-- http-client
-- random
 - aeson
 - aeson-casing
-- memory
+- base >= 4.7 && < 5
+- base16-bytestring
+- bytestring
+- data-default-class
+- exceptions
 - hs-abci-types
+- http-client
+- http-conduit
+- memory
+- mtl
+- random
+- text
+- time
 
 library:
   source-dirs: src

--- a/hs-tendermint-client/src/Network/Tendermint/Client.hs
+++ b/hs-tendermint-client/src/Network/Tendermint/Client.hs
@@ -40,50 +40,21 @@ defaultConfig
   -> Int
   -- ^ Port
   -> RPC.Config
-defaultConfig host port = RPC.Config
-  $ HTTP.setRequestHost host
-  $ HTTP.setRequestPort port
-  $ HTTP.defaultRequest
+defaultConfig host port =
+  let baseReq =
+          HTTP.setRequestHost host
+        $ HTTP.setRequestPort port
+        $ HTTP.defaultRequest
+  in RPC.Config baseReq mempty mempty
 
--- | invokes [/abci_info](https://tendermint.com/rpc/#abciinfo) rpc call
--- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/abci.go#L100
-abciInfo :: TendermintM ResultABCIInfo
-abciInfo = RPC.remote (RPC.MethodName "abci_info") ()
--- | invokes [/health](https://tendermint.com/rpc/#health) rpc call
--- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/health.go#L35
-health :: TendermintM ResultHealth
-health = RPC.remote (RPC.MethodName "health") ()
+--------------------------------------------------------------------------------
+-- ABCI Query
+--------------------------------------------------------------------------------
+
 -- | invokes [/abci_query](https://tendermint.com/rpc/#abciquery) rpc call
 -- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/abci.go#L56
 abciQuery :: RequestABCIQuery -> TendermintM ResultABCIQuery
 abciQuery = RPC.remote (RPC.MethodName "abci_query")
--- | invokes [/block](https://tendermint.com/rpc/#block) rpc call
--- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/blocks.go#L72
-block :: RequestBlock -> TendermintM ResultBlock
-block = RPC.remote (RPC.MethodName "block")
--- | invokes [/tx](https://tendermint.com/rpc/#tx) rpc call
--- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/tx.go#L81
-tx :: RequestTx -> TendermintM ResultTx
-tx = RPC.remote (RPC.MethodName "tx")
--- | invokes [/broadcast_tx_async](https://tendermint.com/rpc/#broadcasttxasync) rpc call
--- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/mempool.go#L75
-broadcastTxAsync :: RequestBroadcastTxAsync -> TendermintM ResultBroadcastTx
-broadcastTxAsync = RPC.remote (RPC.MethodName "broadcast_tx_async")
--- | invokes [/broadcast_tx_sync](https://tendermint.com/rpc/#broadcasttxsync) rpc call
--- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/mempool.go#L136
-broadcastTxSync :: RequestBroadcastTxSync -> TendermintM ResultBroadcastTx
-broadcastTxSync = RPC.remote (RPC.MethodName "broadcast_tx_sync")
--- | invokes [/broadcast_tx_commit](https://tendermint.com/rpc/#broadcasttxcommit) rpc call
--- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/mempool.go#L215
-broadcastTxCommit :: RequestBroadcastTxCommit -> TendermintM ResultBroadcastTxCommit
-broadcastTxCommit = RPC.remote (RPC.MethodName "broadcast_tx_commit")
-
-
-
-defaultRPCOptions :: String -> Aeson.Options
-defaultRPCOptions prefix = aesonDrop (length prefix) snakeCase
-
-
 
 -- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/abci.go#L56
 data RequestABCIQuery = RequestABCIQuery
@@ -104,6 +75,22 @@ instance Default RequestABCIQuery where
       , requestABCIQueryProve = False
       }
 
+-- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/types/responses.go#L193
+data ResultABCIQuery = ResultABCIQuery
+  { resultABCIQueryResponse :: Response.Query
+  } deriving (Eq, Show, Generic)
+instance FromJSON ResultABCIQuery where
+  parseJSON = genericParseJSON $ defaultRPCOptions "resultABCIQuery"
+
+--------------------------------------------------------------------------------
+-- Block
+--------------------------------------------------------------------------------
+
+-- | invokes [/block](https://tendermint.com/rpc/#block) rpc call
+-- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/blocks.go#L72
+block :: RequestBlock -> TendermintM ResultBlock
+block = RPC.remote (RPC.MethodName "block")
+
 -- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/blocks.go#L72
 data RequestBlock = RequestBlock
   { requestBlockHeightPtr :: Maybe Int64
@@ -116,6 +103,24 @@ instance Default RequestBlock where
     RequestBlock
       { requestBlockHeightPtr = Nothing
       }
+
+-- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/types/responses.go#L28
+data ResultBlock = ResultBlock
+  { resultBlockBlockMeta :: BlockMeta
+  , resultBlockBlock     :: Block
+  } deriving (Eq, Show, Generic)
+instance FromJSON ResultBlock where
+  parseJSON = genericParseJSON $ defaultRPCOptions "resultBlock"
+
+
+--------------------------------------------------------------------------------
+-- Tx
+--------------------------------------------------------------------------------
+
+-- | invokes [/tx](https://tendermint.com/rpc/#tx) rpc call
+-- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/tx.go#L81
+tx :: RequestTx -> TendermintM ResultTx
+tx = RPC.remote (RPC.MethodName "tx")
 
 -- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/tx.go#L81
 data RequestTx = RequestTx
@@ -132,58 +137,6 @@ instance Default RequestTx where
       , requestTxProve = False
       }
 
--- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/mempool.go#L75
-data RequestBroadcastTxAsync = RequestBroadcastTxAsync
-  { requestBroadcastTxAsyncTx :: Tx
-  } deriving (Eq, Show, Generic)
-instance ToJSON RequestBroadcastTxAsync where
-  toJSON = genericToJSON $ defaultRPCOptions "requestBroadcastTxAsync"
-
--- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/mempool.go#L136
-data RequestBroadcastTxSync = RequestBroadcastTxSync
-  { requestBroadcastTxSyncTx :: Tx
-  } deriving (Eq, Show, Generic)
-instance ToJSON RequestBroadcastTxSync where
-  toJSON = genericToJSON $ defaultRPCOptions "requestBroadcastTxSync"
-
--- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/mempool.go#L215
-data RequestBroadcastTxCommit = RequestBroadcastTxCommit
-  { requestBroadcastTxCommitTx :: Tx
-  } deriving (Eq, Show, Generic)
-instance ToJSON RequestBroadcastTxCommit where
-  toJSON = genericToJSON $ defaultRPCOptions "requestBroadcastTxCommit"
-
-
--- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/types/responses.go#L208
-data ResultHealth = ResultHealth deriving (Eq, Show)
-
-instance FromJSON ResultHealth where
-  parseJSON = Aeson.withObject "Expected emptyObject" $ \_ ->
-    pure ResultHealth
-
-
--- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/types/responses.go#L188
-data ResultABCIInfo = ResultABCIInfo
-  { resultABCIInfoResponse :: Response.Info
-  } deriving (Eq, Show, Generic)
-instance FromJSON ResultABCIInfo where
-  parseJSON = genericParseJSON $ defaultRPCOptions "resultABCIInfo"
-
--- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/types/responses.go#L193
-data ResultABCIQuery = ResultABCIQuery
-  { resultABCIQueryResponse :: Response.Query
-  } deriving (Eq, Show, Generic)
-instance FromJSON ResultABCIQuery where
-  parseJSON = genericParseJSON $ defaultRPCOptions "resultABCIQuery"
-
--- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/types/responses.go#L28
-data ResultBlock = ResultBlock
-  { resultBlockBlockMeta :: BlockMeta
-  , resultBlockBlock     :: Block
-  } deriving (Eq, Show, Generic)
-instance FromJSON ResultBlock where
-  parseJSON = genericParseJSON $ defaultRPCOptions "resultBlock"
-
 -- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/types/responses.go#L164
 data ResultTx = ResultTx
   { resultTxHash     :: HexString
@@ -196,15 +149,53 @@ data ResultTx = ResultTx
 instance FromJSON ResultTx where
   parseJSON = genericParseJSON $ defaultRPCOptions "resultTx"
 
--- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/types/responses.go#L147
-data ResultBroadcastTx = ResultBroadcastTx
-  { resultBroadcastTxCode :: Word32
-  , resultBroadcastTxData :: HexString
-  , resultBroadcastTxLog  :: Text
-  , resultBroadcastTxHash :: HexString
+--------------------------------------------------------------------------------
+-- BroadcastTxAsync
+--------------------------------------------------------------------------------
+
+-- | invokes [/broadcast_tx_async](https://tendermint.com/rpc/#broadcasttxasync) rpc call
+-- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/mempool.go#L75
+broadcastTxAsync :: RequestBroadcastTxAsync -> TendermintM ResultBroadcastTx
+broadcastTxAsync = RPC.remote (RPC.MethodName "broadcast_tx_async")
+
+-- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/mempool.go#L75
+data RequestBroadcastTxAsync = RequestBroadcastTxAsync
+  { requestBroadcastTxAsyncTx :: Tx
   } deriving (Eq, Show, Generic)
-instance FromJSON ResultBroadcastTx where
-  parseJSON = genericParseJSON $ defaultRPCOptions "resultBroadcastTx"
+instance ToJSON RequestBroadcastTxAsync where
+  toJSON = genericToJSON $ defaultRPCOptions "requestBroadcastTxAsync"
+
+--------------------------------------------------------------------------------
+-- BroadcastTxSync
+--------------------------------------------------------------------------------
+
+-- | invokes [/broadcast_tx_sync](https://tendermint.com/rpc/#broadcasttxsync) rpc call
+-- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/mempool.go#L136
+broadcastTxSync :: RequestBroadcastTxSync -> TendermintM ResultBroadcastTx
+broadcastTxSync = RPC.remote (RPC.MethodName "broadcast_tx_sync")
+
+-- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/mempool.go#L136
+data RequestBroadcastTxSync = RequestBroadcastTxSync
+  { requestBroadcastTxSyncTx :: Tx
+  } deriving (Eq, Show, Generic)
+instance ToJSON RequestBroadcastTxSync where
+  toJSON = genericToJSON $ defaultRPCOptions "requestBroadcastTxSync"
+
+--------------------------------------------------------------------------------
+-- BroadcastTxCommit
+--------------------------------------------------------------------------------
+
+-- | invokes [/broadcast_tx_commit](https://tendermint.com/rpc/#broadcasttxcommit) rpc call
+-- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/mempool.go#L215
+broadcastTxCommit :: RequestBroadcastTxCommit -> TendermintM ResultBroadcastTxCommit
+broadcastTxCommit = RPC.remote (RPC.MethodName "broadcast_tx_commit")
+
+-- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/mempool.go#L215
+data RequestBroadcastTxCommit = RequestBroadcastTxCommit
+  { requestBroadcastTxCommitTx :: Tx
+  } deriving (Eq, Show, Generic)
+instance ToJSON RequestBroadcastTxCommit where
+  toJSON = genericToJSON $ defaultRPCOptions "requestBroadcastTxCommit"
 
 -- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/types/responses.go#L156
 data ResultBroadcastTxCommit = ResultBroadcastTxCommit
@@ -215,6 +206,51 @@ data ResultBroadcastTxCommit = ResultBroadcastTxCommit
   } deriving (Eq, Show, Generic)
 instance FromJSON ResultBroadcastTxCommit where
   parseJSON = genericParseJSON $ defaultRPCOptions "resultBroadcastTxCommit"
+
+
+--------------------------------------------------------------------------------
+-- Health
+--------------------------------------------------------------------------------
+
+-- | invokes [/health](https://tendermint.com/rpc/#health) rpc call
+-- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/health.go#L35
+health :: TendermintM ResultHealth
+health = RPC.remote (RPC.MethodName "health") ()
+
+-- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/types/responses.go#L208
+data ResultHealth = ResultHealth deriving (Eq, Show)
+
+instance FromJSON ResultHealth where
+  parseJSON = Aeson.withObject "Expected emptyObject" $ \_ ->
+    pure ResultHealth
+
+--------------------------------------------------------------------------------
+-- ABCIInfo
+--------------------------------------------------------------------------------
+
+-- | invokes [/abci_info](https://tendermint.com/rpc/#abciinfo) rpc call
+-- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/abci.go#L100
+abciInfo :: TendermintM ResultABCIInfo
+abciInfo = RPC.remote (RPC.MethodName "abci_info") ()
+
+-- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/types/responses.go#L188
+data ResultABCIInfo = ResultABCIInfo
+  { resultABCIInfoResponse :: Response.Info
+  } deriving (Eq, Show, Generic)
+instance FromJSON ResultABCIInfo where
+  parseJSON = genericParseJSON $ defaultRPCOptions "resultABCIInfo"
+
+--------------------------------------------------------------------------------
+
+-- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/types/responses.go#L147
+data ResultBroadcastTx = ResultBroadcastTx
+  { resultBroadcastTxCode :: Word32
+  , resultBroadcastTxData :: HexString
+  , resultBroadcastTxLog  :: Text
+  , resultBroadcastTxHash :: HexString
+  } deriving (Eq, Show, Generic)
+instance FromJSON ResultBroadcastTx where
+  parseJSON = genericParseJSON $ defaultRPCOptions "resultBroadcastTx"
 
 -- https://github.com/tendermint/tendermint/blob/v0.32.2/types/tx.go#L85
 data TxProof = TxProof
@@ -309,4 +345,5 @@ instance FromJSON SignedMsgType where
     32 -> pure ProposalType
     _  -> fail $ "invalid SignedMsg code: " <> show n
 
-
+defaultRPCOptions :: String -> Aeson.Options
+defaultRPCOptions prefix = aesonDrop (length prefix) snakeCase

--- a/hs-tendermint-client/src/Network/Tendermint/Client/Internal/RPCClient.hs
+++ b/hs-tendermint-client/src/Network/Tendermint/Client/Internal/RPCClient.hs
@@ -76,9 +76,6 @@ data Config = Config
   { cBaseHTTPRequest :: HTTP.Request
   }
 
-defaultConfig :: Config
-defaultConfig = Config HTTP.defaultRequest
-
 remote ::
   ( MonadIO m
   , MonadThrow m


### PR DESCRIPTION
Set up a basic test suite for the example application. finishes #22 

e2e test suite: **blocked**
1. Check the node is alive via `/health`
2. Check that the count was initialized to `0`
3. Set the count to something
4. Query the new count and make sure it got set

application test suite
replicate steps 2 - 4 from above but without using the rpc client. Just plug into the handlers directly. **NOTE** there is no reason to start the node in this case