### PR TITLE
Event buffer fix

### DIFF
--- a/hs-abci-examples/nameservice/src/Nameservice/Modules/Nameservice.hs
+++ b/hs-abci-examples/nameservice/src/Nameservice/Modules/Nameservice.hs
@@ -48,7 +48,7 @@ import           Tendermint.SDK.Application               (Module (..),
 import           Tendermint.SDK.BaseApp                   (BaseAppEffs)
 
 type NameserviceM r =
-  Module "nameservice" NameserviceMessage Api NameserviceEffs r
+  Module "nameservice" NameserviceMessage () Api NameserviceEffs r
 
 nameserviceModule
   :: Members BaseAppEffs r

--- a/hs-abci-examples/nameservice/src/Nameservice/Modules/Nameservice/Router.hs
+++ b/hs-abci-examples/nameservice/src/Nameservice/Modules/Nameservice/Router.hs
@@ -6,7 +6,7 @@ import           Nameservice.Modules.Nameservice.Keeper   (NameserviceEffs,
 import           Nameservice.Modules.Nameservice.Messages (NameserviceMessage (..))
 import           Nameservice.Modules.Token                (TokenEffs)
 import           Polysemy                                 (Members, Sem)
-import           Tendermint.SDK.BaseApp                   (BaseAppEffs,
+import           Tendermint.SDK.BaseApp                   (BaseAppEffs, TxEffs,
                                                            incCount, withTimer)
 import           Tendermint.SDK.Types.Message             (Msg (..))
 import           Tendermint.SDK.Types.Transaction         (RoutedTx (..),
@@ -16,6 +16,7 @@ router
   :: Members TokenEffs r
   => Members NameserviceEffs r
   => Members BaseAppEffs r
+  => Members TxEffs r
   => RoutedTx NameserviceMessage
   -> Sem r ()
 router (RoutedTx Tx{txMsg}) =

--- a/hs-abci-examples/nameservice/src/Nameservice/Modules/Token.hs
+++ b/hs-abci-examples/nameservice/src/Nameservice/Modules/Token.hs
@@ -45,7 +45,7 @@ import           Tendermint.SDK.Application         (Module (..),
 import           Tendermint.SDK.BaseApp             (BaseAppEffs)
 import           Tendermint.SDK.Types.Address       (Address)
 
-type TokenM r = Module "token" TokenMessage Api TokenEffs r
+type TokenM r = Module "token" TokenMessage () Api TokenEffs r
 
 tokenModule
   :: Members BaseAppEffs r

--- a/hs-abci-examples/nameservice/test/Nameservice/Test/E2ESpec.hs
+++ b/hs-abci-examples/nameservice/test/Nameservice/Test/E2ESpec.hs
@@ -297,6 +297,7 @@ mkSignedRawTransactionWithRoute route privateKey msg = sign unsigned
   where unsigned = RawTransaction { rawTransactionData = encodeMsgData msg
                                   , rawTransactionRoute = cs route
                                   , rawTransactionSignature = ""
+                                  , rawTransactionGas = 0
                                   }
         sig = signRawTransaction algProxy privateKey unsigned
         sign rt = rt { rawTransactionSignature = encodeCompactRecSig $ exportCompactRecSig sig }

--- a/hs-abci-examples/nameservice/test/Nameservice/Test/E2ESpec.hs
+++ b/hs-abci-examples/nameservice/test/Nameservice/Test/E2ESpec.hs
@@ -159,27 +159,37 @@ spec = do
         clientResponseData `shouldBe` Nothing
 
       it "Can fail a transfer (failure 1)" $ do
-        let msg = TypedMessage "Transfer" (encode $ Transfer addr2 addr1 2000)
+        let senderBeforeQueryReq = defaultQueryWithData addr2
+        addr2Balance <- getQueryResponseSuccess $ getBalance senderBeforeQueryReq
+        let tooMuchToTransfer = addr2Balance + 1
+            msg = TypedMessage "Transfer" (encode $ Transfer addr2 addr1 tooMuchToTransfer)
             rawTx = mkSignedRawTransactionWithRoute "token" privateKey1 msg
         ensureCheckAndDeliverResponseCodes (0,1) rawTx
 
       it "Can transfer (success 0)" $ do
-        let senderBeforeQueryReq = defaultQueryWithData addr2
-        senderBeforeFoundAmount <- getQueryResponseSuccess $ getBalance senderBeforeQueryReq
-        senderBeforeFoundAmount `shouldBe` Amount 1700
-        let msg = TypedMessage "Transfer" (encode $ Transfer addr1 addr2 500)
-            transferEvent = TransferEvent 500 addr1 addr2
+        balance1 <- getQueryResponseSuccess $ getBalance $ defaultQueryWithData addr1
+        balance2 <- getQueryResponseSuccess $ getBalance $ defaultQueryWithData addr2
+        let transferAmount = 1
+            msg = TypedMessage "Transfer" $ encode
+              Transfer
+                { transferFrom = addr1
+                , transferTo = addr2
+                , transferAmount = transferAmount
+                }
+            transferEvent = TransferEvent
+              { transferEventAmount = transferAmount
+              , transferEventTo = addr2
+              , transferEventFrom = addr1
+              }
             rawTx = mkSignedRawTransactionWithRoute "token" privateKey1 msg
         deliverResp <- getDeliverTxResponse rawTx
         ensureDeliverResponseCode deliverResp 0
         ensureEventLogged deliverResp "TransferEvent" transferEvent
         -- check balances
-        let receiverQueryReq = defaultQueryWithData addr1
-        receiverFoundAmount <- getQueryResponseSuccess $ getBalance receiverQueryReq
-        receiverFoundAmount `shouldBe` Amount 1800
-        let senderAfterQueryReq = defaultQueryWithData addr2
-        senderAfterFoundAmount <- getQueryResponseSuccess $ getBalance senderAfterQueryReq
-        senderAfterFoundAmount `shouldBe` Amount 1200
+        balance1' <- getQueryResponseSuccess $ getBalance $ defaultQueryWithData addr1
+        balance1' `shouldBe` balance1 - transferAmount
+        balance2' <- getQueryResponseSuccess $ getBalance $ defaultQueryWithData addr2
+        balance2' `shouldBe` balance2 + transferAmount
 
 --------------------------------------------------------------------------------
 user1 :: User

--- a/hs-abci-examples/nameservice/tutorial/Foundations/Modules.md
+++ b/hs-abci-examples/nameservice/tutorial/Foundations/Modules.md
@@ -5,9 +5,9 @@
 A `Module` has a very specific meaning in the context of this SDK. A `Module` is something between a library and a small state machine. It is built on top of the `BaseApp` abstraction in the sense that all `Module`s must be explicitly interpeted in terms of `BaseApp` in order to compile the application. The full type definition is
 
 ~~~ haskell ignore
-data Module (name :: Symbol) msg (api :: *) (s :: EffectRow) (r :: EffectRow) = Module
-  { moduleTxDeliverer :: RoutedTx msg -> Sem r ()
-  , moduleTxChecker   :: RoutedTx msg -> Sem r ()
+data Module (name :: Symbol) msg (api :: *) (val :: *) (s :: EffectRow) (r :: EffectRow) = Module
+  { moduleTxDeliverer :: RoutedTx msg -> Sem r val
+  , moduleTxChecker   :: RoutedTx msg -> Sem r val
   , moduleQueryServer :: RouteT api (Sem r)
   , moduleEval :: forall deps. Members BaseAppEffs deps => forall a. Sem (s :& deps) a -> Sem deps a
   }
@@ -17,6 +17,7 @@ where the type parameters
 
 - `name` is the name of the module, e.g. `"bank"`.
 - `msg` is the type of the incoming messages the module must handle.
+- `val` is the type of the return value (must be common across all messages the module receives).
 - `api` is the query api for querying state in the url format (more on this later).  
 - `s` is the set of effects introduced by this module.
 - `r` is the global set of effects that this module will run in when part of a larger application (more on this later).

--- a/hs-abci-examples/nameservice/tutorial/Tutorial/Nameservice/Module.md
+++ b/hs-abci-examples/nameservice/tutorial/Tutorial/Nameservice/Module.md
@@ -20,7 +20,7 @@ import Tendermint.SDK.BaseApp                   (BaseAppEffs)
 
 -- a convenient type alias
 type NameserviceM r =
-  Module NameserviceModuleName NameserviceMessage Api NameserviceEffs r
+  Module NameserviceModuleName NameserviceMessage () Api NameserviceEffs r
 
 nameserviceModule
   :: Members BaseAppEffs r

--- a/hs-abci-examples/simple-storage/src/SimpleStorage/Modules/SimpleStorage.hs
+++ b/hs-abci-examples/simple-storage/src/SimpleStorage/Modules/SimpleStorage.hs
@@ -18,7 +18,7 @@ import           Tendermint.SDK.Application                  (Module (..),
 import qualified Tendermint.SDK.BaseApp                      as BaseApp
 
 type SimpleStorageM r =
-  Module "simple_storage" SimpleStorageMessage Api SimpleStorageEffs r
+  Module "simple_storage" SimpleStorageMessage () Api SimpleStorageEffs r
 
 simpleStorageModule
   :: Member SimpleStorage r

--- a/hs-abci-examples/simple-storage/src/SimpleStorage/Modules/SimpleStorage/Router.hs
+++ b/hs-abci-examples/simple-storage/src/SimpleStorage/Modules/SimpleStorage/Router.hs
@@ -2,24 +2,25 @@ module SimpleStorage.Modules.SimpleStorage.Router
   ( router
   ) where
 
-import           Polysemy                                    (Members, Sem)
-import           Polysemy.Output                             (Output)
+import           Polysemy                                    (Member, Members,
+                                                              Sem)
 import           SimpleStorage.Modules.SimpleStorage.Keeper  (SimpleStorage,
-                                                              putCount)
+                                                              updateCount)
 import           SimpleStorage.Modules.SimpleStorage.Message
 import           SimpleStorage.Modules.SimpleStorage.Types   (Count (..))
-import           Tendermint.SDK.BaseApp                      (Event)
+import           Tendermint.SDK.BaseApp                      (TxEffs)
 import           Tendermint.SDK.Types.Message                (Msg (..))
 import           Tendermint.SDK.Types.Transaction            (RoutedTx (..),
                                                               Tx (..))
 
 
 router
-  :: Members [SimpleStorage, Output Event] r
+  :: Member SimpleStorage r
+  => Members TxEffs r
   => RoutedTx SimpleStorageMessage
   -> Sem r ()
 router (RoutedTx Tx{txMsg}) =
   let Msg{msgData} = txMsg
   in case msgData of
        UpdateCount UpdateCountTx{updateCountTxCount} ->
-          putCount (Count updateCountTxCount)
+          updateCount (Count updateCountTxCount)

--- a/hs-abci-examples/simple-storage/test/SimpleStorage/Test/E2ESpec.hs
+++ b/hs-abci-examples/simple-storage/test/SimpleStorage/Test/E2ESpec.hs
@@ -108,6 +108,7 @@ mkSignedRawTransaction privateKey msg = sign unsigned
   where unsigned = RawTransaction { rawTransactionData = encode msg
                                   , rawTransactionRoute = "simple_storage"
                                   , rawTransactionSignature = ""
+                                  , rawTransactionGas = 0
                                   }
         sig = signRawTransaction algProxy privateKey unsigned
         sign rt = rt { rawTransactionSignature = Serial.encode $ exportCompactRecSig sig }

--- a/hs-abci-sdk/package.yaml
+++ b/hs-abci-sdk/package.yaml
@@ -117,9 +117,10 @@ library:
   - Tendermint.SDK.Codec
   - Tendermint.SDK.Crypto
   - Tendermint.SDK.Modules.Auth
+  - Tendermint.SDK.Types.Address
+  - Tendermint.SDK.Types.Effects
   - Tendermint.SDK.Types.Message
   - Tendermint.SDK.Types.Transaction
-  - Tendermint.SDK.Types.Address
   - Tendermint.SDK.Types.TxResult
 
   generated-exposed-modules:

--- a/hs-abci-sdk/protos/types/transaction.proto
+++ b/hs-abci-sdk/protos/types/transaction.proto
@@ -3,6 +3,7 @@ package Transaction;
 
 message RawTransaction {
   bytes data = 1;
-  bytes signature = 2;
-  string route = 3;
+  int64 gas = 2;
+  bytes signature = 3;
+  string route = 4;
 }

--- a/hs-abci-sdk/src/Tendermint/SDK/BaseApp.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/BaseApp.hs
@@ -12,7 +12,6 @@ module Tendermint.SDK.BaseApp
   , Context(..)
   , contextLogConfig
   , contextPrometheusEnv
-  , contextEventBuffer
   , contextAuthTree
   , makeContext
   , runCoreEffs
@@ -53,6 +52,9 @@ module Tendermint.SDK.BaseApp
   , CountName(..)
   , HistogramName(..)
 
+  -- * Transaction
+  , TxEffs
+
   -- * Query
   , Queryable(..)
   , FromQueryData(..)
@@ -71,3 +73,5 @@ import           Tendermint.SDK.BaseApp.Logger
 import           Tendermint.SDK.BaseApp.Metrics
 import           Tendermint.SDK.BaseApp.Query
 import           Tendermint.SDK.BaseApp.Store
+import           Tendermint.SDK.BaseApp.Transaction
+import           Tendermint.SDK.Types.Effects       ((:&))

--- a/hs-abci-sdk/src/Tendermint/SDK/BaseApp/BaseApp.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/BaseApp/BaseApp.hs
@@ -5,20 +5,16 @@ module Tendermint.SDK.BaseApp.BaseApp
   , ScopedEff(..)
   , compileScopedEff
   , compileToCoreEffs
-  , (:&)
   ) where
 
 import           Control.Exception                          (throwIO)
 import           Control.Monad.IO.Class                     (liftIO)
 import           Polysemy                                   (Sem)
 import           Polysemy.Error                             (Error, runError)
-import           Polysemy.Output                            (Output)
 import           Polysemy.Resource                          (Resource,
                                                              resourceToIO)
 import           Tendermint.SDK.BaseApp.CoreEff             (CoreEffs)
 import           Tendermint.SDK.BaseApp.Errors              (AppError)
-import           Tendermint.SDK.BaseApp.Events              (Event,
-                                                             evalWithBuffer)
 import           Tendermint.SDK.BaseApp.Logger              (Logger)
 import qualified Tendermint.SDK.BaseApp.Logger.Katip        as KL
 import           Tendermint.SDK.BaseApp.Metrics             (Metrics)
@@ -27,26 +23,18 @@ import           Tendermint.SDK.BaseApp.Store               (ApplyScope, Connect
                                                              RawStore,
                                                              ResolveScope (..))
 import qualified Tendermint.SDK.BaseApp.Store.AuthTreeStore as AT
+import           Tendermint.SDK.Types.Effects               ((:&))
 
 -- | Concrete row of effects for the BaseApp. Note that because there does
 -- | not exist an interpreter for an untagged 'RawStore', you must scope
 -- | these effects before they can be interpreted.
 type BaseAppEffs =
   [ RawStore
-  , Output Event
   , Metrics
   , Logger
   , Resource
   , Error AppError
   ]
-
--- | This type family gives a nice syntax for combining multiple lists of effects.
-type family (as :: [a]) :& (bs :: [a]) :: [a] where
-  '[] :& bs = bs
-  (a ': as) :& bs = a ': (as :& bs)
-
-infixr 5 :&
-
 type BaseApp r = BaseAppEffs :& r
 
 type ScopedBaseApp (s :: ConnectionScope) r = ApplyScope s (BaseApp r)
@@ -60,7 +48,6 @@ compileToCoreEffs action = do
     resourceToIO .
     KL.evalKatip .
     Prometheus.evalWithMetrics .
-    evalWithBuffer .
     resolveScope $ action
   either (liftIO . throwIO) return eRes
 

--- a/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Errors.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Errors.hs
@@ -2,8 +2,7 @@ module Tendermint.SDK.BaseApp.Errors
   ( AppError(..)
   , IsAppError(..)
   , queryAppError
-  , checkTxAppError
-  , deliverTxAppError
+  , txResultAppError
   , SDKError(..)
   , throwSDKError
   ) where
@@ -15,6 +14,7 @@ import           Data.Word                            (Word32)
 import qualified Network.ABCI.Types.Messages.Response as Response
 import           Polysemy
 import           Polysemy.Error                       (Error, throw)
+import           Tendermint.SDK.Types.TxResult        (TxResult (..))
 
 -- | This type represents a common error response for the query, checkTx,
 -- | and deliver tx abci-messages.
@@ -31,7 +31,7 @@ instance Exception AppError
 class IsAppError e where
   makeAppError :: e -> AppError
 
--- | This class is used to set the 'AppError' data into the appropriate
+-- | This lens is used to set the 'AppError' data into the appropriate
 -- | response fields for the query abci-message.
 queryAppError :: Lens' Response.Query AppError
 queryAppError = lens g s
@@ -47,36 +47,20 @@ queryAppError = lens g s
       , Response.queryLog = appErrorMessage
       }
 
--- | This class is used to set the 'AppError' data into the appropriate
--- | response fields for the checkTx abci-message.
-checkTxAppError :: Lens' Response.CheckTx AppError
-checkTxAppError = lens g s
+-- | This lens is used to set the 'AppError' data into the appropriate
+-- | response fields for the checkTx/deliverTx abci-message.
+txResultAppError :: Lens' TxResult AppError
+txResultAppError = lens g s
   where
-    g Response.CheckTx{..} = AppError
-      { appErrorCode = checkTxCode
-      , appErrorCodespace = checkTxCodespace
-      , appErrorMessage = checkTxLog
+    g TxResult{..} = AppError
+      { appErrorCode = _txResultCode
+      , appErrorCodespace = _txResultCodespace
+      , appErrorMessage = _txResultLog
       }
-    s checkTx AppError{..} = checkTx
-      { Response.checkTxCode = appErrorCode
-      , Response.checkTxCodespace  = appErrorCodespace
-      , Response.checkTxLog = appErrorMessage
-      }
-
--- | This class is used to set the 'AppError' data into the appropriate
--- | response fields for the deliverTx abci-message.
-deliverTxAppError :: Lens' Response.DeliverTx AppError
-deliverTxAppError = lens g s
-  where
-    g Response.DeliverTx{..} = AppError
-      { appErrorCode = deliverTxCode
-      , appErrorCodespace = deliverTxCodespace
-      , appErrorMessage = deliverTxLog
-      }
-    s deliverTx AppError{..} = deliverTx
-      { Response.deliverTxCode = appErrorCode
-      , Response.deliverTxCodespace  = appErrorCodespace
-      , Response.deliverTxLog = appErrorMessage
+    s txResult AppError{..} = txResult
+      { _txResultCode = appErrorCode
+      , _txResultCodespace  = appErrorCodespace
+      , _txResultLog = appErrorMessage
       }
 
 --------------------------------------------------------------------------------

--- a/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Events.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Events.hs
@@ -4,32 +4,21 @@ module Tendermint.SDK.BaseApp.Events
   , FromEvent(..)
   , emit
   , makeEvent
-  , EventBuffer
-  , newEventBuffer
-  , withEventBuffer
-  , evalWithBuffer
   ) where
 
-import qualified Control.Concurrent.MVar                as MVar
 import           Control.Error                          (fmapL)
-import           Control.Monad                          (void)
-import           Control.Monad.IO.Class
 import qualified Data.Aeson                             as A
 import           Data.Bifunctor                         (bimap)
 import qualified Data.ByteArray.Base64String            as Base64
 import qualified Data.ByteString                        as BS
-import qualified Data.List                              as L
 import           Data.Proxy
 import           Data.String.Conversions                (cs)
 import           Data.Text                              (Text)
 import           GHC.Exts                               (fromList, toList)
 import           Network.ABCI.Types.Messages.FieldTypes (Event (..),
                                                          KVPair (..))
-import           Polysemy                               (Embed, Member, Sem,
-                                                         interpret)
-import           Polysemy.Output                        (Output (..), output)
-import           Polysemy.Reader                        (Reader (..), ask)
-import           Polysemy.Resource                      (Resource, onException)
+import           Polysemy                               (Member, Sem)
+import           Polysemy.Output                        (Output, output)
 
 {-
 TODO : These JSON instances are fragile but convenient. We
@@ -70,41 +59,6 @@ class ToEvent e => FromEvent e where
              kvPairs <- traverse fromKVPair eventAttributes
              A.eitherDecode . A.encode . A.Object . fromList $ kvPairs
 
--- This is the internal implementation of the interpreter for event
--- logging. We allocate a buffer that can queue events as they are thrown,
--- then flush the buffer at the end of transaction execution. It will
--- also flush in the event that exceptions are thrown.
-
-data EventBuffer = EventBuffer (MVar.MVar [Event])
-
-newEventBuffer :: IO EventBuffer
-newEventBuffer = EventBuffer <$> MVar.newMVar []
-
-appendEvent
-  :: MonadIO (Sem r)
-  => Event
-  -> EventBuffer
-  -> Sem r ()
-appendEvent e (EventBuffer b) = do
-  liftIO (MVar.modifyMVar_ b (pure . (e :)))
-
-flushEventBuffer
-  :: MonadIO (Sem r)
-  => EventBuffer
-  -> Sem r [Event]
-flushEventBuffer (EventBuffer b) = do
-  liftIO (L.reverse <$> MVar.swapMVar b [])
-
-withEventBuffer
-  :: Member Resource r
-  => Member (Reader EventBuffer) r
-  => MonadIO (Sem r)
-  => Sem r ()
-  -> Sem r [Event]
-withEventBuffer action = do
-  buffer <- ask
-  onException (action *> flushEventBuffer buffer) (void $ flushEventBuffer buffer)
-
 makeEvent
   :: ToEvent e
   => e
@@ -120,11 +74,3 @@ emit
   => e
   -> Sem r ()
 emit e = output $ makeEvent e
-
-evalWithBuffer
-  :: Member (Embed IO) r
-  => Member (Reader EventBuffer) r
-  => (forall a. Sem (Output Event ': r) a -> Sem r a)
-evalWithBuffer action = interpret (\case
-  Output e -> ask >>= appendEvent e
-  ) action

--- a/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Gas.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Gas.hs
@@ -15,7 +15,7 @@ import           Tendermint.SDK.BaseApp.Errors (AppError,
                                                 SDKError (OutOfGasException),
                                                 throwSDKError)
 
-newtype GasAmount = GasAmount { unGasAmount :: Int64 } deriving (Eq, Num, Ord)
+newtype GasAmount = GasAmount { unGasAmount :: Int64 } deriving (Eq, Show, Num, Ord)
 
 data GasMeter m a where
     WithGas :: forall m a. GasAmount -> m a -> GasMeter m a

--- a/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Gas.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Gas.hs
@@ -1,39 +1,40 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Tendermint.SDK.BaseApp.Gas
   ( GasMeter(..)
+  , GasAmount(..)
   , withGas
   , eval
   ) where
 
-import           Control.Monad.IO.Class        (MonadIO (..))
 import           Data.Int                      (Int64)
-import qualified Data.IORef                    as Ref
-import           Polysemy                      (Embed, Members, Sem, interpretH,
+import           Polysemy                      (Members, Sem, interpretH,
                                                 makeSem, raise, runT)
 import           Polysemy.Error                (Error)
+import           Polysemy.State                (State, get, put)
 import           Tendermint.SDK.BaseApp.Errors (AppError,
                                                 SDKError (OutOfGasException),
                                                 throwSDKError)
 
+newtype GasAmount = GasAmount { unGasAmount :: Int64 } deriving (Eq, Num, Ord)
+
 data GasMeter m a where
-    WithGas :: forall m a. Int64 -> m a -> GasMeter m a
+    WithGas :: forall m a. GasAmount -> m a -> GasMeter m a
 
 makeSem ''GasMeter
 
+
 eval
-  :: Members [Error AppError, Embed IO] r
-  => Ref.IORef Int64
-  -> Sem (GasMeter ': r) a
+  :: Members [Error AppError, State GasAmount] r
+  => Sem (GasMeter ': r) a
   -> Sem r a
-eval meter = interpretH (\case
+eval = interpretH (\case
   WithGas gasCost action -> do
-    remainingGas <- liftIO $ Ref.readIORef meter
+    remainingGas <- get
     let balanceAfterAction = remainingGas - gasCost
     if balanceAfterAction < 0
       then throwSDKError OutOfGasException
       else do
-        liftIO $ Ref.writeIORef meter balanceAfterAction
+        put balanceAfterAction
         a <- runT action
-        raise $ eval meter a
+        raise $ eval a
   )
-

--- a/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Metrics.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Metrics.hs
@@ -28,6 +28,6 @@ data Metrics m a where
   -- | Increments the count of a specific message
   IncCount :: CountName -> Metrics m ()
   -- | Times an action and records it in a histogram
-  WithTimer :: HistogramName -> m a -> Metrics m ()
+  WithTimer :: HistogramName -> m a -> Metrics m a
 
 makeSem ''Metrics

--- a/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Metrics/Prometheus.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Metrics/Prometheus.hs
@@ -166,7 +166,9 @@ evalNothing
 evalNothing = do
   interpretH (\case
     IncCount _ -> pureT ()
-    WithTimer _ _ -> pureT ()
+    WithTimer _ action -> do
+      a <- runT action
+      raise $ evalNothing a
     )
 
 evalMetrics
@@ -203,8 +205,7 @@ evalMetrics state@MetricsState{..} = do
       end <- liftIO $ getCurrentTime
       let time = fromRational . (* 1000.0) . toRational $ (end `diffUTCTime` start)
       observeHistogram state histName time
-      _ <- raise $ evalMetrics state a
-      pureT ()
+      raise $ evalMetrics state a
     )
 
 -- | Updates a histogram with an observed value

--- a/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Transaction.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Transaction.hs
@@ -60,14 +60,15 @@ eval TransactionContext{..} action = do
       runStateIORef gas .
       G.eval .
       raiseUnder @(State G.GasAmount) $
-      runOutputMonoidAssocR pure action
+      runOutputMonoidAssocR (pure @[]) action
   gasRemaining <- liftIO $ readIORef gas
   let gasUsed = initialGas - gasRemaining
       baseResponse =
         def & txResultGasWanted .~ G.unGasAmount initialGas
             & txResultGasUsed .~ G.unGasAmount gasUsed
   return $ case eRes of
-    Left e -> baseResponse & txResultAppError .~ e
+    Left e ->
+      baseResponse & txResultAppError .~ e
     Right (events, a) ->
       baseResponse & txResultEvents .~ events
                    & txResultData .~ Base64.fromBytes (encode a)

--- a/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Transaction.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Transaction.hs
@@ -1,0 +1,65 @@
+module Tendermint.SDK.BaseApp.Transaction
+  ( TxEffs
+  , TransactionContext(..)
+  , newTransactionContext
+  , eval
+  ) where
+
+import           Control.Lens                     ((&), (.~))
+import qualified Data.ByteArray.Base64String      as Base64
+import           Data.Default.Class               (def)
+import           Polysemy                         (Sem, raiseUnder)
+import           Polysemy.Error                   (Error, runError)
+import           Polysemy.Output                  (Output,
+                                                   runOutputMonoidAssocR)
+import           Polysemy.State                   (State, runState)
+import           Tendermint.SDK.BaseApp.Errors    (AppError, txResultAppError)
+import qualified Tendermint.SDK.BaseApp.Events    as E
+import qualified Tendermint.SDK.BaseApp.Gas       as G
+import           Tendermint.SDK.Codec             (HasCodec (encode))
+import           Tendermint.SDK.Types.Effects     ((:&))
+import           Tendermint.SDK.Types.Transaction (RoutedTx (..), Tx (..))
+import           Tendermint.SDK.Types.TxResult    (TxResult, txResultData,
+                                                   txResultEvents,
+                                                   txResultGasUsed,
+                                                   txResultGasWanted)
+
+type TxEffs =
+    [ Output E.Event
+    , G.GasMeter
+    , Error AppError
+    ]
+
+data TransactionContext = TransactionContext
+  { initialGas :: G.GasAmount
+  }
+
+newTransactionContext
+  :: RoutedTx msg
+  -> TransactionContext
+newTransactionContext (RoutedTx Tx{txGas}) = do
+  TransactionContext
+    { initialGas = G.GasAmount txGas
+    }
+
+eval
+  :: forall r a.
+     HasCodec a
+  => TransactionContext
+  -> Sem (TxEffs :& r) a
+  -> Sem r TxResult
+eval TransactionContext{..} action = do
+  eRes <-
+    runError .
+      runState initialGas .
+      G.eval .
+      raiseUnder @(State G.GasAmount) $
+      runOutputMonoidAssocR pure action
+  return $ case eRes of
+    Left e -> def & txResultAppError .~ e
+    Right (gasRemaining, (events, a)) ->
+      let gasUsed = initialGas - gasRemaining
+      in def & txResultEvents .~ events
+             & txResultData .~ Base64.fromBytes (encode a)
+             & txResultGasWanted .~ G.unGasAmount initialGas
+             & txResultGasUsed .~ G.unGasAmount gasUsed

--- a/hs-abci-sdk/src/Tendermint/SDK/Codec.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Codec.hs
@@ -14,5 +14,9 @@ class HasCodec a where
     encode :: a -> BS.ByteString
     decode :: BS.ByteString -> Either Text a
 
+instance HasCodec () where
+  encode = const ""
+  decode = const $ pure ()
+
 defaultSDKAesonOptions :: String -> Options
 defaultSDKAesonOptions prefix = aesonDrop (length prefix) snakeCase

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Auth.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Auth.hs
@@ -22,7 +22,7 @@ import           Tendermint.SDK.Modules.Auth.Keeper
 import           Tendermint.SDK.Modules.Auth.Query
 import           Tendermint.SDK.Modules.Auth.Types
 
-type AuthM r = Module AuthModule Void Api AuthEffs r
+type AuthM r = Module AuthModule Void Void Api AuthEffs r
 
 authModule
   :: Members BaseAppEffs r

--- a/hs-abci-sdk/src/Tendermint/SDK/Types/Effects.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Types/Effects.hs
@@ -8,4 +8,3 @@ type family (as :: [a]) :& (bs :: [a]) :: [a] where
   (a ': as) :& bs = a ': (as :& bs)
 
 infixr 5 :&
-

--- a/hs-abci-sdk/src/Tendermint/SDK/Types/Effects.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Types/Effects.hs
@@ -1,0 +1,11 @@
+module Tendermint.SDK.Types.Effects
+  ( (:&)
+  ) where
+
+-- | This type family gives a nice syntax for combining multiple lists of effects.
+type family (as :: [a]) :& (bs :: [a]) :: [a] where
+  '[] :& bs = bs
+  (a ': as) :& bs = a ': (as :& bs)
+
+infixr 5 :&
+

--- a/hs-abci-sdk/src/Tendermint/SDK/Types/TxResult.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Types/TxResult.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Tendermint.SDK.Types.TxResult where
 
-import           Control.Lens                           (Lens', lens)
+import           Control.Lens                           (Iso', iso)
 import           Control.Lens.TH                        (makeLenses)
 import           Data.ByteArray.Base64String            (Base64String)
 import           Data.Default.Class                     (Default (..))
 import           Data.Int                               (Int64)
 import           Data.Text                              (Text)
+import           Data.Word                              (Word32)
 import           Network.ABCI.Types.Messages.FieldTypes (Event, WrappedVal (..))
 import qualified Network.ABCI.Types.Messages.Response   as Response
 
@@ -18,6 +19,9 @@ data TxResult = TxResult
   , _txResultGasWanted :: Int64
   , _txResultGasUsed   :: Int64
   , _txResultEvents    :: [Event]
+  , _txResultCode      :: Word32
+  , _txResultLog       :: Text
+  , _txResultCodespace :: Text
   } deriving Show
 
 makeLenses ''TxResult
@@ -29,12 +33,15 @@ instance Default TxResult where
     , _txResultGasWanted = 0
     , _txResultGasUsed  = 0
     , _txResultEvents   = []
+    , _txResultCode = 0
+    , _txResultLog = ""
+    , _txResultCodespace = ""
     }
 
 -- | This class is used to set the 'TxResult' data into the appropriate
 -- | response fields for the CheckTx abci-message.
-checkTxTxResult :: Lens' Response.CheckTx TxResult
-checkTxTxResult = lens g s
+checkTxTxResult :: Iso' Response.CheckTx TxResult
+checkTxTxResult = iso g s
   where
     g Response.CheckTx{..} = TxResult
       { _txResultData = checkTxData
@@ -42,19 +49,25 @@ checkTxTxResult = lens g s
       , _txResultGasWanted = unWrappedVal checkTxGasWanted
       , _txResultGasUsed = unWrappedVal checkTxGasUsed
       , _txResultEvents = checkTxEvents
+      , _txResultCode = checkTxCode
+      , _txResultLog = checkTxLog
+      , _txResultCodespace = checkTxCodespace
       }
-    s checkTx TxResult{..} = checkTx
+    s TxResult{..} = Response.CheckTx
       { Response.checkTxData = _txResultData
       , Response.checkTxInfo  = _txResultInfo
       , Response.checkTxGasWanted = WrappedVal _txResultGasWanted
       , Response.checkTxGasUsed = WrappedVal _txResultGasUsed
       , Response.checkTxEvents = _txResultEvents
+      , Response.checkTxCode = _txResultCode
+      , Response.checkTxCodespace = _txResultCodespace
+      , Response.checkTxLog = _txResultLog
       }
 
 -- | This class is used to set the 'TxResult' data into the appropriate
 -- | response fields for the DeliverTx abci-message.
-deliverTxTxResult :: Lens' Response.DeliverTx TxResult
-deliverTxTxResult = lens g s
+deliverTxTxResult :: Iso' Response.DeliverTx TxResult
+deliverTxTxResult = iso g s
   where
     g Response.DeliverTx{..} = TxResult
       { _txResultData = deliverTxData
@@ -62,11 +75,17 @@ deliverTxTxResult = lens g s
       , _txResultGasWanted = unWrappedVal deliverTxGasWanted
       , _txResultGasUsed = unWrappedVal deliverTxGasUsed
       , _txResultEvents = deliverTxEvents
+      , _txResultCode = deliverTxCode
+      , _txResultLog = deliverTxLog
+      , _txResultCodespace = deliverTxCodespace
       }
-    s deliverTx TxResult{..} = deliverTx
+    s TxResult{..} = Response.DeliverTx
       { Response.deliverTxData = _txResultData
       , Response.deliverTxInfo  = _txResultInfo
       , Response.deliverTxGasWanted = WrappedVal _txResultGasWanted
       , Response.deliverTxGasUsed = WrappedVal _txResultGasUsed
       , Response.deliverTxEvents = _txResultEvents
+      , Response.deliverTxCode = _txResultCode
+      , Response.deliverTxCodespace = _txResultCodespace
+      , Response.deliverTxLog = _txResultLog
       }

--- a/hs-abci-sdk/test/Tendermint/SDK/Test/CryptoSpec.hs
+++ b/hs-abci-sdk/test/Tendermint/SDK/Test/CryptoSpec.hs
@@ -20,6 +20,7 @@ spec = describe "Crypto Tests" $ do
             { rawTransactionData = "abcd"
             , rawTransactionSignature = ""
             , rawTransactionRoute= "dog"
+            , rawTransactionGas = 10
             }
           signature = signRawTransaction algProxy privateKey rawTxWithoutSig
           rawTxWithSig = rawTxWithoutSig {rawTransactionSignature =


### PR DESCRIPTION
This PR addresses the following issues:

1. You couldn't return anything but () from a transaction even though there is a way to do that in the response type
2. Ouput Event was part of BaseApp, even though it makes no sense to do that outside of a transaction
3. There was a GasMeter effect that was not incorporated into BaseApp, but again that makes no sense outside of a transaction