### PR TITLE
Include types.proto for modules for type reuse

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -80,6 +80,8 @@
         - Proto.Modules.Auth_Fields
         - Proto.Modules.Bank
         - Proto.Modules.Bank_Fields
+        - Proto.Modules.Types
+        - Proto.Modules.Types_Fields
         - Proto.Types.Transaction
         - Proto.Types.Transaction_Fields
     - message:
@@ -89,6 +91,8 @@
         - Proto.Modules.Auth_Fields
         - Proto.Modules.Bank
         - Proto.Modules.Bank_Fields
+        - Proto.Modules.Types
+        - Proto.Modules.Types_Fields
         - Proto.Types.Transaction
         - Proto.Types.Transaction_Fields
     - message:

--- a/hs-abci-sdk/package.yaml
+++ b/hs-abci-sdk/package.yaml
@@ -146,6 +146,8 @@ library:
   - Proto.Modules.Auth_Fields
   - Proto.Modules.Bank
   - Proto.Modules.Bank_Fields
+  - Proto.Modules.Types
+  - Proto.Modules.Types_Fields
   - Proto.Types.Transaction
   - Proto.Types.Transaction_Fields
 

--- a/hs-abci-sdk/protos/modules/auth.proto
+++ b/hs-abci-sdk/protos/modules/auth.proto
@@ -1,17 +1,11 @@
 syntax = "proto3";
 package Auth;
 
-message CoinId {
-  string id = 1;
-}
-
-message Amount {
-  uint64 amount = 1;
-}
+import "modules/types.proto";
 
 message Coin {
-  CoinId id = 1;
-  Amount amount = 2;
+  modules.CoinId id = 1;
+  modules.Amount amount = 2;
 }
 
 message Account {

--- a/hs-abci-sdk/protos/modules/bank.proto
+++ b/hs-abci-sdk/protos/modules/bank.proto
@@ -1,15 +1,17 @@
 syntax = "proto3";
 package Bank;
 
+import "modules/types.proto";
+
 message Transfer {
   bytes to = 1;
   bytes from = 2;
-  string cid = 3;
-  uint64 amount = 4;
+  modules.CoinId cid = 3;
+  modules.Amount amount = 4;
 }
 
 message Burn {
   bytes address = 1;
-  string cid = 2;
-  uint64 amount = 3;
+  modules.CoinId cid = 2;
+  modules.Amount amount = 3;
 }

--- a/hs-abci-sdk/protos/modules/types.proto
+++ b/hs-abci-sdk/protos/modules/types.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+package modules;
+
+message CoinId {
+  string id = 1;
+}
+
+message Amount {
+  uint64 amount = 1;
+}

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Auth/Types.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Auth/Types.hs
@@ -18,6 +18,8 @@ import           GHC.Generics                 (Generic)
 import           GHC.TypeLits                 (symbolVal)
 import qualified Proto.Modules.Auth           as A
 import qualified Proto.Modules.Auth_Fields    as A
+import qualified Proto.Modules.Types          as AT
+import qualified Proto.Modules.Types_Fields   as AT
 import           Tendermint.SDK.BaseApp       (AppError (..), IsAppError (..),
                                                IsKey (..), Queryable (..))
 import           Tendermint.SDK.Codec         (HasCodec (..),
@@ -58,15 +60,15 @@ instance IsAppError AuthError where
 newtype CoinId = CoinId { unCoinId :: Text } deriving (Eq, Show, Generic)
 
 instance Wrapped CoinId where
-  type Unwrapped CoinId = A.CoinId
+  type Unwrapped CoinId = AT.CoinId
 
   _Wrapped' = iso t f
    where
     t CoinId {..} =
       P.defMessage
-        & A.id .~ unCoinId
+        & AT.id .~ unCoinId
     f message = CoinId
-      { unCoinId = message ^. A.id
+      { unCoinId = message ^. AT.id
       }
 
 instance HasCodec CoinId where
@@ -90,15 +92,15 @@ newtype Amount = Amount { unAmount :: Word64 }
   deriving (Eq, Show, Num, Generic, Ord, JSON.ToJSON, JSON.FromJSON)
 
 instance Wrapped Amount where
-  type Unwrapped Amount = A.Amount
+  type Unwrapped Amount = AT.Amount
 
   _Wrapped' = iso t f
    where
     t Amount {..} =
       P.defMessage
-        & A.amount .~ unAmount
+        & AT.amount .~ unAmount
     f message = Amount
-      { unAmount = message ^. A.amount
+      { unAmount = message ^. AT.amount
       }
 
 instance HasCodec Amount where

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Bank/Messages.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Bank/Messages.hs
@@ -1,7 +1,7 @@
 module Tendermint.SDK.Modules.Bank.Messages where
 
 import           Control.Lens                 (Wrapped (..), from, iso, view,
-                                               (&), (.~), (^.))
+                                               (&), (.~), (^.), _Unwrapped')
 import           Data.Bifunctor               (bimap)
 import qualified Data.ProtoLens               as P
 import           Data.String.Conversions      (cs)
@@ -32,13 +32,13 @@ instance Wrapped Transfer where
       P.defMessage
         & B.to .~ addressToBytes transferTo
         & B.from .~ addressToBytes transferFrom
-        & B.cid .~ unCoinId transferCoinId
-        & B.amount .~ unAmount transferAmount
+        & B.cid .~ transferCoinId ^. _Wrapped'
+        & B.amount .~ transferAmount ^. _Wrapped'
     f message = Transfer
       { transferTo = addressFromBytes $ message ^. B.to
       , transferFrom = addressFromBytes $ message ^. B.from
-      , transferCoinId = CoinId $ message ^. B.cid
-      , transferAmount = Amount $ message ^. B.amount
+      , transferCoinId = message ^. B.cid . _Unwrapped'
+      , transferAmount = message ^. B.amount . _Unwrapped'
       }
 
 instance HasMessageType Transfer where
@@ -67,12 +67,12 @@ instance Wrapped Burn where
     t Burn {..} =
       P.defMessage
         & B.address .~ addressToBytes burnAddress
-        & B.cid .~ unCoinId burnCoinId
-        & B.amount .~ unAmount burnAmount
+        & B.cid .~ burnCoinId ^. _Wrapped'
+        & B.amount .~ burnAmount ^. _Wrapped'
     f message = Burn
       { burnAddress = addressFromBytes $ message ^. B.address
-      , burnCoinId = CoinId $ message ^. B.cid
-      , burnAmount = Amount $ message ^. B.amount
+      , burnCoinId = message ^. B.cid . _Unwrapped'
+      , burnAmount = message ^. B.amount . _Unwrapped'
       }
 
 instance HasMessageType Burn where


### PR DESCRIPTION
Very low hanging fruit. 

Basically wanted to do this when #201 was merged, which included the protos for `Bank` and `Auth`, but, at the time, I didn't know how to reuse the types for `CoinId` and `Amount` in the protobuf files themselves. 

This includes that very minor change.