### PR TITLE
Validators module

### DIFF
--- a/hs-abci-sdk/package.yaml
+++ b/hs-abci-sdk/package.yaml
@@ -135,6 +135,7 @@ library:
   - Tendermint.SDK.Crypto
   - Tendermint.SDK.Modules.Auth
   - Tendermint.SDK.Modules.Bank
+  - Tendermint.SDK.Modules.Validators
   - Tendermint.SDK.Types.Address
   - Tendermint.SDK.Types.Effects
   - Tendermint.SDK.Types.Message

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators.hs
@@ -1,0 +1,26 @@
+module Tendermint.SDK.Modules.Validators (Validators, validatorsModule, endBlock) where
+
+
+import           Polysemy                                   (Members)
+import           Tendermint.SDK.Application                 (Module (..),
+                                                             ModuleEffs)
+import           Tendermint.SDK.BaseApp                     (EmptyTxServer (..))
+import           Tendermint.SDK.Modules.Validators.EndBlock
+import           Tendermint.SDK.Modules.Validators.Keeper
+import           Tendermint.SDK.Modules.Validators.Query
+import           Tendermint.SDK.Modules.Validators.Types
+
+
+type Validators = Module ValidatorsName EmptyTxServer EmptyTxServer QueryApi ValidatorsEffs '[]
+
+validatorsModule ::
+  Members (ModuleEffs Validators) r =>
+  Validators r
+validatorsModule =
+  Module
+    { moduleTxDeliverer = EmptyTxServer,
+      moduleTxChecker = EmptyTxServer,
+      moduleQuerier = querier,
+      moduleEval = eval
+    }
+

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators.hs
@@ -1,4 +1,13 @@
-module Tendermint.SDK.Modules.Validators (Validators, validatorsModule, endBlock) where
+module Tendermint.SDK.Modules.Validators
+  (
+    Validators
+  , validatorsModule
+
+  , module Tendermint.SDK.Modules.Validators.Keeper
+  , module Tendermint.SDK.Modules.Validators.Types
+
+  , endBlock
+  ) where
 
 
 import           Polysemy                                   (Members)

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/EndBlock.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/EndBlock.hs
@@ -49,4 +49,4 @@ endBlock _ = do
   pure $ EndBlockResult (map convertToValUp (Map.assocs updatesMap)) Nothing
   where
     convertToValUp (PubKey_ key, power) =
-      ABCI.ValidatorUpdate key (ABCI.WrappedVal (fromIntegral power))
+      ABCI.ValidatorUpdate (Just key) (ABCI.WrappedVal (fromIntegral power))

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/EndBlock.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/EndBlock.hs
@@ -1,0 +1,50 @@
+module Tendermint.SDK.Modules.Validators.EndBlock where
+
+import           Control.Monad                            (foldM)
+import qualified Data.Map.Strict                          as Map
+import qualified Data.Set                                 as Set
+import qualified Network.ABCI.Types.Messages.FieldTypes   as ABCI
+import qualified Network.ABCI.Types.Messages.Request      as Request
+import           Polysemy                                 (Members, Sem)
+import           Tendermint.SDK.BaseApp                   (BlockEffs,
+                                                           EndBlockResult (..))
+import qualified Tendermint.SDK.BaseApp.Store.List        as L
+import qualified Tendermint.SDK.BaseApp.Store.Map         as M
+import qualified Tendermint.SDK.BaseApp.Store.Var         as V
+import           Tendermint.SDK.Modules.Validators.Keeper
+import           Tendermint.SDK.Modules.Validators.Store
+import           Tendermint.SDK.Modules.Validators.Types
+
+
+endBlock
+  :: Members BlockEffs r
+  => Members ValidatorsEffs r
+  => Request.EndBlock
+  -> Sem r EndBlockResult
+endBlock _ = do
+  updatesMap <- getQueuedUpdates
+  curValKeySet <- getValidatorsKeys
+
+  -- update the Validators map and key set
+  newValKeySet <- foldM (\cvks (key, newPower) ->
+      if newPower == 0 then do
+        -- delete from Validators map and key set
+        M.delete key validatorsMap
+        return (Set.delete key cvks)
+      else do
+        -- update power in Validators map and ensure key is in key set
+        M.insert key newPower validatorsMap
+        return (Set.insert key cvks)
+    ) curValKeySet (Map.assocs updatesMap)
+
+  -- store new set of validator keys
+  V.putVar (KeySet newValKeySet) validatorsKeySet
+
+  -- reset the updatesList to empty
+  L.deleteWhen (const True) updatesList
+
+  -- return EndBlockResult with validator updates for Tendermint
+  pure $ EndBlockResult (map convertToValUp (Map.assocs updatesMap)) Nothing
+  where
+    convertToValUp (PubKey_ key, power) =
+      ABCI.ValidatorUpdate (Just key) (ABCI.WrappedVal (fromIntegral power))

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Keeper.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Keeper.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Tendermint.SDK.Modules.Validators.Keeper where
+
+import qualified Data.Map.Strict                         as Map
+import           Data.Maybe                              (fromMaybe)
+import qualified Data.Set                                as Set
+import           Data.Word                               (Word64)
+import           Polysemy                                (Members, Sem,
+                                                          interpret, makeSem)
+import           Polysemy.Error                          (Error)
+import           Tendermint.SDK.BaseApp                  (AppError, ReadStore,
+                                                          WriteStore)
+import qualified Tendermint.SDK.BaseApp.Store.List       as L
+import qualified Tendermint.SDK.BaseApp.Store.Map        as M
+import qualified Tendermint.SDK.BaseApp.Store.Var        as V
+import           Tendermint.SDK.Modules.Validators.Store
+import           Tendermint.SDK.Modules.Validators.Types
+
+
+data ValidatorsKeeper m a where
+  GetValidators :: ValidatorsKeeper m (Map.Map PubKey_ Word64)
+  GetValidatorsKeys :: ValidatorsKeeper m (Set.Set PubKey_)
+  GetPowerOf :: PubKey_ -> ValidatorsKeeper m Word64
+  GetQueuedUpdates :: ValidatorsKeeper m (Map.Map PubKey_ Word64)
+  GetQueuedUpdate :: PubKey_ -> ValidatorsKeeper m (Maybe Word64)
+  QueueUpdate :: PubKey_ -> Word64 -> ValidatorsKeeper m ()
+  QueueUpdates :: [(PubKey_, Word64)] -> ValidatorsKeeper m ()
+
+makeSem ''ValidatorsKeeper
+
+type ValidatorsEffs = '[ValidatorsKeeper]
+
+eval
+  :: Members [ReadStore, WriteStore, Error AppError] r
+  => Sem (ValidatorsKeeper : r) a
+  -> Sem r a
+eval = interpret (\case
+  GetValidators -> getValidatorsF
+  GetValidatorsKeys -> getValidatorsKeysF
+  GetPowerOf key -> getPowerOfF key
+  GetQueuedUpdates -> getQueuedUpdatesF
+  GetQueuedUpdate key -> getQueuedUpdateF key
+  QueueUpdate key power -> queueUpdateF key power
+  QueueUpdates updates -> queueUpdatesF updates
+  )
+
+getValidatorsF
+  :: Members [ReadStore, Error AppError] r
+  => Sem r (Map.Map PubKey_ Word64)
+getValidatorsF = do
+  keyList <- fmap Set.toList getValidatorsKeysF
+  fmap Map.fromList $ mapM (\k -> fmap (\p -> (k, p)) (getPowerOfF k)) keyList
+
+getValidatorsKeysF
+  :: Members [ReadStore, Error AppError] r
+  => Sem r (Set.Set PubKey_)
+getValidatorsKeysF =
+  fmap (maybe Set.empty (\(KeySet x) -> x)) $ V.takeVar validatorsKeySet
+
+getPowerOfF
+  :: Members [ReadStore, Error AppError] r
+  => PubKey_
+  -> Sem r Word64
+getPowerOfF key =
+  fmap (fromMaybe 0) $ M.lookup key validatorsMap
+
+getQueuedUpdatesF
+  :: Members [ReadStore, Error AppError] r
+  => Sem r (Map.Map PubKey_ Word64)
+getQueuedUpdatesF = L.foldl (\m ValidatorUpdate{..} ->
+  Map.alter (maybe (Just power) Just) key m) Map.empty updatesList
+
+getQueuedUpdateF
+  :: Members [ReadStore, Error AppError] r
+  => PubKey_
+  -> Sem r (Maybe Word64)
+getQueuedUpdateF key =
+  fmap (Map.lookup key) getQueuedUpdatesF
+
+queueUpdateF
+  :: Members [ReadStore, WriteStore, Error AppError] r
+  => PubKey_
+  -> Word64
+  -> Sem r ()
+queueUpdateF key power =
+  L.append (ValidatorUpdate key power) updatesList
+
+queueUpdatesF
+  :: Members [ReadStore, WriteStore, Error AppError] r
+  => [(PubKey_, Word64)]
+  -> Sem r ()
+queueUpdatesF = mapM_ $ uncurry queueUpdateF
+

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Keeper.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Keeper.hs
@@ -69,7 +69,7 @@ getQueuedUpdatesF
   :: Members [ReadStore, Error AppError] r
   => Sem r (Map.Map PubKey_ Word64)
 getQueuedUpdatesF = L.foldl (\m ValidatorUpdate{..} ->
-  Map.alter (maybe (Just power) Just) key m) Map.empty updatesList
+  Map.alter (Just . fromMaybe power) key m) Map.empty updatesList
 
 getQueuedUpdateF
   :: Members [ReadStore, Error AppError] r

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Keeper.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Keeper.hs
@@ -3,7 +3,7 @@
 module Tendermint.SDK.Modules.Validators.Keeper where
 
 import qualified Data.Map.Strict                         as Map
-import           Data.Maybe                              (fromJust, fromMaybe)
+import           Data.Maybe                              (fromMaybe)
 import qualified Data.Set                                as Set
 import           Data.Word                               (Word64)
 import           Network.ABCI.Types.Messages.FieldTypes
@@ -60,7 +60,7 @@ getQueuedUpdatesF = L.foldl (\m (ValidatorUpdate_ ValidatorUpdate{..}) ->
   Map.alter (Just . fromMaybe (toWord validatorUpdatePower)) (toPK_ validatorUpdatePubKey) m) Map.empty updatesList
   where
     toWord (WrappedVal x) = fromIntegral x
-    toPK_ = PubKey_ . fromJust
+    toPK_ = PubKey_ . fromMaybe (error "Bad ValidatorUpdate with Nothing PubKey found in queued updates")
 
 queueUpdateF
   :: Members [ReadStore, WriteStore, Error AppError] r

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Query.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Query.hs
@@ -1,4 +1,8 @@
-module Tendermint.SDK.Modules.Validators.Query where
+module Tendermint.SDK.Modules.Validators.Query
+  (
+    querier
+  , QueryApi
+  )where
 
 import qualified Data.Map.Strict                          as Map
 import qualified Data.Set                                 as Set

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Query.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Query.hs
@@ -1,6 +1,7 @@
 module Tendermint.SDK.Modules.Validators.Query where
 
 import qualified Data.Map.Strict                          as Map
+import qualified Data.Set                                 as Set
 import           Data.Word                                (Word64)
 import           Polysemy                                 (Members, Sem)
 import           Servant.API
@@ -37,7 +38,8 @@ getValidators
   :: Members Keeper.ValidatorsEffs r
   => Sem r (QueryResult (Map.Map PubKey_ Word64))
 getValidators = do
-  vs <- Keeper.getValidators
+  keyList <- fmap Set.toList Keeper.getValidatorsKeys
+  vs <- fmap Map.fromList $ mapM (\k -> fmap (\p -> (k, p)) (Keeper.getPowerOf k)) keyList
   pure $ QueryResult
     { queryResultData = vs
     , queryResultIndex = 0

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Query.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Query.hs
@@ -1,0 +1,51 @@
+module Tendermint.SDK.Modules.Validators.Query where
+
+import qualified Data.Map.Strict                          as Map
+import           Data.Word                                (Word64)
+import           Polysemy                                 (Members, Sem)
+import           Servant.API
+import           Tendermint.SDK.BaseApp
+import qualified Tendermint.SDK.BaseApp.Store.Map         as M
+import qualified Tendermint.SDK.BaseApp.Store.Var         as V
+import qualified Tendermint.SDK.Modules.Validators.Keeper as Keeper
+import           Tendermint.SDK.Modules.Validators.Store
+import           Tendermint.SDK.Modules.Validators.Types
+
+type QueryApi = GetPowerOf :<|> GetValidatorsKeys :<|> GetValidators
+
+querier
+  :: Members QueryEffs r
+  => Members Keeper.ValidatorsEffs r
+  => RouteQ QueryApi r
+querier =
+  getPowerOfQuery :<|> getValidatorsKeys :<|> getValidators
+
+type GetPowerOf = "powerOf" :> StoreLeaf (M.Map PubKey_ Word64)
+getPowerOfQuery
+  :: Members QueryEffs r
+  => RouteQ GetPowerOf r
+getPowerOfQuery = storeQueryHandler validatorsMap
+
+type GetValidatorsKeys = "validatorsKeys" :> StoreLeaf (V.Var KeySet)
+getValidatorsKeys
+  :: Members QueryEffs r
+  => RouteQ GetValidatorsKeys r
+getValidatorsKeys = storeQueryHandler validatorsKeySet
+
+type GetValidators = "validators" :> Leaf (Map.Map PubKey_ Word64)
+getValidators
+  :: Members Keeper.ValidatorsEffs r
+  => Sem r (QueryResult (Map.Map PubKey_ Word64))
+getValidators = do
+  vs <- Keeper.getValidators
+  pure $ QueryResult
+    { queryResultData = vs
+    , queryResultIndex = 0
+    , queryResultKey = ""
+    , queryResultProof = Nothing
+    , queryResultHeight = 0
+    }
+
+
+
+

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Store.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Store.hs
@@ -15,7 +15,7 @@ import           Tendermint.SDK.Modules.Validators.Types
 store :: Store ValidatorsNameSpace
 store = makeStore $ KeyRoot "validators"
 
-$(makeSubStore 'store "updatesList" [t|L.List ValidatorUpdate|] updatesListKey)
+$(makeSubStore 'store "updatesList" [t|L.List ValidatorUpdate_|] updatesListKey)
 
 $(makeSubStore 'store "validatorsMap" [t|M.Map PubKey_ Word64|] validatorsMapKey)
 

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Store.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Store.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Tendermint.SDK.Modules.Validators.Store where
+
+import           Data.Word                               (Word64)
+import           Tendermint.SDK.BaseApp                  (KeyRoot (..), Store,
+                                                          makeStore)
+import qualified Tendermint.SDK.BaseApp.Store.List       as L
+import qualified Tendermint.SDK.BaseApp.Store.Map        as M
+import           Tendermint.SDK.BaseApp.Store.TH         (makeSubStore)
+import qualified Tendermint.SDK.BaseApp.Store.Var        as V
+import           Tendermint.SDK.Modules.Validators.Types
+
+
+store :: Store ValidatorsNameSpace
+store = makeStore $ KeyRoot "validators"
+
+$(makeSubStore 'store "updatesList" [t|L.List ValidatorUpdate|] updatesListKey)
+
+$(makeSubStore 'store "validatorsMap" [t|M.Map PubKey_ Word64|] validatorsMapKey)
+
+$(makeSubStore 'store "validatorsKeySet" [t|V.Var KeySet|] validatorsKeySetKey)
+

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Store.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Store.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-module Tendermint.SDK.Modules.Validators.Store where
+module Tendermint.SDK.Modules.Validators.Store
+  (
+    updatesList
+  , validatorsMap
+  , validatorsKeySet
+  ) where
 
 import           Data.Word                               (Word64)
 import           Tendermint.SDK.BaseApp                  (KeyRoot (..), Store,

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Types.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Types.hs
@@ -1,14 +1,19 @@
 module Tendermint.SDK.Modules.Validators.Types where
 
-import           Control.Lens                           (iso)
+import           Control.Lens                           (Wrapped (_Wrapped'),
+                                                         iso, (^.), _Unwrapped')
 import qualified Data.Aeson                             as A
+import           Data.Bifunctor                         (Bifunctor (bimap, second))
 import           Data.ByteString                        (ByteString)
 import           Data.ByteString.Lazy                   (toStrict)
-import           Data.Maybe                             (fromJust)
+import           Data.Either                            (fromRight)
+import           Data.ProtoLens                         (decodeMessage,
+                                                         encodeMessage)
 import           Data.Set                               (Set)
-import           Data.Word                              (Word64)
+import           Data.Text                              (pack)
 import           GHC.Generics                           (Generic)
-import           Network.ABCI.Types.Messages.FieldTypes (PubKey)
+import           Network.ABCI.Types.Messages.FieldTypes (PubKey (PubKey),
+                                                         ValidatorUpdate)
 import           Tendermint.SDK.BaseApp                 (RawKey (..))
 import           Tendermint.SDK.Codec                   (HasCodec (..))
 
@@ -28,24 +33,23 @@ validatorsKeySetKey :: ByteString
 validatorsKeySetKey = "validatorsKeySet"
 
 
-data ValidatorUpdate = ValidatorUpdate
-    { key   :: PubKey_
-    , power :: Word64
-    }
-    deriving Generic
-instance A.ToJSON ValidatorUpdate
-instance A.FromJSON ValidatorUpdate
-instance HasCodec ValidatorUpdate where
-  encode = toStrict . A.encode
-  decode s = maybe (Left "failure to decode ValidatorUpdate") Right (A.decodeStrict s)
+newtype ValidatorUpdate_ = ValidatorUpdate_ ValidatorUpdate deriving (Eq, Generic)
 
+instance HasCodec ValidatorUpdate_ where
+  encode (ValidatorUpdate_ vu) = encodeMessage $ (vu ^. _Wrapped')
+  decode bs = bimap pack (ValidatorUpdate_ . (^. _Unwrapped')) $ decodeMessage bs
 
 newtype PubKey_ = PubKey_ PubKey deriving (Eq, Ord, Generic)
+
+instance RawKey PubKey_ where
+  rawKey = iso t f
+    where
+      t (PubKey_ p) = encodeMessage $ (p ^. _Wrapped')
+      f = PubKey_ . fromRight (PubKey "" "") . second (^. _Unwrapped') . decodeMessage
+
+
 instance A.ToJSON PubKey_
 instance A.FromJSON PubKey_
-instance RawKey PubKey_ where
-  rawKey = iso (\(PubKey_ p) -> (toStrict . A.encode) p) (PubKey_ . fromJust . A.decodeStrict)
-
 
 newtype KeySet = KeySet (Set PubKey_) deriving Generic
 instance A.ToJSON KeySet

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Types.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Types.hs
@@ -10,7 +10,7 @@ import           Data.Either                            (fromRight)
 import           Data.ProtoLens                         (decodeMessage,
                                                          encodeMessage)
 import           Data.Set                               (Set)
-import           Data.Text                              (pack)
+import           Data.String.Conversions                (cs)
 import           GHC.Generics                           (Generic)
 import           Network.ABCI.Types.Messages.FieldTypes (PubKey (PubKey),
                                                          ValidatorUpdate)
@@ -37,7 +37,7 @@ newtype ValidatorUpdate_ = ValidatorUpdate_ ValidatorUpdate deriving (Eq, Generi
 
 instance HasCodec ValidatorUpdate_ where
   encode (ValidatorUpdate_ vu) = encodeMessage $ (vu ^. _Wrapped')
-  decode bs = bimap pack (ValidatorUpdate_ . (^. _Unwrapped')) $ decodeMessage bs
+  decode bs = bimap cs (ValidatorUpdate_ . (^. _Unwrapped')) $ decodeMessage bs
 
 newtype PubKey_ = PubKey_ PubKey deriving (Eq, Ord, Generic)
 

--- a/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Types.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/Modules/Validators/Types.hs
@@ -1,0 +1,55 @@
+module Tendermint.SDK.Modules.Validators.Types where
+
+import           Control.Lens                           (iso)
+import qualified Data.Aeson                             as A
+import           Data.ByteString                        (ByteString)
+import           Data.ByteString.Lazy                   (toStrict)
+import           Data.Maybe                             (fromJust)
+import           Data.Set                               (Set)
+import           Data.Word                              (Word64)
+import           GHC.Generics                           (Generic)
+import           Network.ABCI.Types.Messages.FieldTypes (PubKey)
+import           Tendermint.SDK.BaseApp                 (RawKey (..))
+import           Tendermint.SDK.Codec                   (HasCodec (..))
+
+
+data ValidatorsNameSpace
+
+type ValidatorsName = "validators"
+
+
+updatesListKey :: ByteString
+updatesListKey = "updatesList"
+
+validatorsMapKey :: ByteString
+validatorsMapKey = "validatorsMap"
+
+validatorsKeySetKey :: ByteString
+validatorsKeySetKey = "validatorsKeySet"
+
+
+data ValidatorUpdate = ValidatorUpdate
+    { key   :: PubKey_
+    , power :: Word64
+    }
+    deriving Generic
+instance A.ToJSON ValidatorUpdate
+instance A.FromJSON ValidatorUpdate
+instance HasCodec ValidatorUpdate where
+  encode = toStrict . A.encode
+  decode s = maybe (Left "failure to decode ValidatorUpdate") Right (A.decodeStrict s)
+
+
+newtype PubKey_ = PubKey_ PubKey deriving (Eq, Ord, Generic)
+instance A.ToJSON PubKey_
+instance A.FromJSON PubKey_
+instance RawKey PubKey_ where
+  rawKey = iso (\(PubKey_ p) -> (toStrict . A.encode) p) (PubKey_ . fromJust . A.decodeStrict)
+
+
+newtype KeySet = KeySet (Set PubKey_) deriving Generic
+instance A.ToJSON KeySet
+instance A.FromJSON KeySet
+instance HasCodec KeySet where
+  encode = toStrict . A.encode
+  decode s = maybe (Left "failure to decode KeySet") Right (A.decodeStrict s)

--- a/hs-abci-types/src/Network/ABCI/Types/Messages/FieldTypes.hs
+++ b/hs-abci-types/src/Network/ABCI/Types/Messages/FieldTypes.hs
@@ -245,7 +245,7 @@ data PubKey = PubKey
   -- ^ Type of the public key.
   , pubKeyData :: Base64String
   -- ^ Public key data.
-  } deriving (Eq, Show, Generic)
+  } deriving (Eq, Ord, Show, Generic)
 
 instance ToJSON PubKey where
   toJSON = genericToJSON $ defaultABCIOptions "pubKey"

--- a/hs-abci-types/src/Network/ABCI/Types/Messages/FieldTypes.hs
+++ b/hs-abci-types/src/Network/ABCI/Types/Messages/FieldTypes.hs
@@ -268,7 +268,7 @@ instance Wrapped PubKey where
           }
 
 data ValidatorUpdate = ValidatorUpdate
-  { validatorUpdatePubKey :: PubKey
+  { validatorUpdatePubKey :: Maybe PubKey
   -- ^ Public key of the validator
   , validatorUpdatePower  :: WrappedVal Int64
   -- ^ Voting power of the validator
@@ -286,11 +286,11 @@ instance Wrapped ValidatorUpdate where
     where
       t ValidatorUpdate{..} =
         defMessage
-          & PT.pubKey .~ validatorUpdatePubKey ^. _Wrapped'
+          & PT.maybe'pubKey .~ validatorUpdatePubKey ^? _Just . _Wrapped'
           & PT.power .~ unWrappedVal validatorUpdatePower
       f a =
         ValidatorUpdate
-          { validatorUpdatePubKey = a ^. PT.pubKey . _Unwrapped'
+          { validatorUpdatePubKey = a ^? PT.maybe'pubKey . _Just . _Unwrapped'
           , validatorUpdatePower = WrappedVal $ a ^. PT.power
           }
 

--- a/hs-abci-types/src/Network/ABCI/Types/Messages/FieldTypes.hs
+++ b/hs-abci-types/src/Network/ABCI/Types/Messages/FieldTypes.hs
@@ -268,7 +268,7 @@ instance Wrapped PubKey where
           }
 
 data ValidatorUpdate = ValidatorUpdate
-  { validatorUpdatePubKey :: Maybe PubKey
+  { validatorUpdatePubKey :: PubKey
   -- ^ Public key of the validator
   , validatorUpdatePower  :: WrappedVal Int64
   -- ^ Voting power of the validator
@@ -286,11 +286,11 @@ instance Wrapped ValidatorUpdate where
     where
       t ValidatorUpdate{..} =
         defMessage
-          & PT.maybe'pubKey .~ validatorUpdatePubKey ^? _Just . _Wrapped'
+          & PT.pubKey .~ validatorUpdatePubKey ^. _Wrapped'
           & PT.power .~ unWrappedVal validatorUpdatePower
       f a =
         ValidatorUpdate
-          { validatorUpdatePubKey = a ^? PT.maybe'pubKey . _Just . _Unwrapped'
+          { validatorUpdatePubKey = a ^. PT.pubKey . _Unwrapped'
           , validatorUpdatePower = WrappedVal $ a ^. PT.power
           }
 


### PR DESCRIPTION
Initial draft of a module for apps to manage validator sets (#252).

Changes from what was described in that issue:
- Addition of store Var to keep a set of the current validator pubkeys, since store Map doesn't have a method to get all keys/values
- Used List type for QueuedUpdates, so that adding an update would be fast, and Map like behavior can be constructed from a foldl
- Used Word64 instead of Natural. Still non-negative, but bounded since Tendermint has a 64bit bound on validator power anyway.
- Didn't implement Queries for QueuedUpdates, since it is always reset in EndBlock, and query is for committed state (it would always be [])

I'm not very familiar with the Query system, so that is in particular need of review.
Also Weeder is going to fail until this has some tests, and I imagine that is going to take a while because I'm not familiar with the Kepler testing system, and proper testing will require multiple Tendermint docker instances.