### PR TITLE
exposing length from array storage module

### DIFF
--- a/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Store/Array.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Store/Array.hs
@@ -5,6 +5,7 @@ module Tendermint.SDK.BaseApp.Store.Array
   , makeArray
   , makeFullStoreKey
   , append
+  , length
   , modifyAtIndex
   , deleteWhen
   , (!!)

--- a/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Store/Array.hs
+++ b/hs-abci-sdk/src/Tendermint/SDK/BaseApp/Store/Array.hs
@@ -6,6 +6,7 @@ module Tendermint.SDK.BaseApp.Store.Array
   , makeFullStoreKey
   , append
   , length
+  , foldl
   , modifyAtIndex
   , deleteWhen
   , (!!)


### PR DESCRIPTION
Fixes #258 

@jlandrews 

I also noticed that `foldl` was not exposed, so went ahead and did that.