### PR TITLE
Fix height parameter in /block

### DIFF
--- a/hs-tendermint-client/src/Network/Tendermint/Client.hs
+++ b/hs-tendermint-client/src/Network/Tendermint/Client.hs
@@ -110,13 +110,13 @@ block = RPC.remote (RPC.MethodName "block")
 
 -- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/blocks.go#L72
 data RequestBlock = RequestBlock
-  { requestBlockHeightPtr :: Maybe (FieldTypes.WrappedVal Int64)
+  { requestBlockHeight :: Maybe (FieldTypes.WrappedVal Int64)
   } deriving (Eq, Show, Generic)
 instance ToJSON RequestBlock where
   toJSON = genericToJSON $ defaultRPCOptions "requestBlock"
 
 instance Default RequestBlock where
-  def = RequestBlock { requestBlockHeightPtr = Nothing }
+  def = RequestBlock { requestBlockHeight = Nothing }
 
 -- https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/types/responses.go#L28
 data ResultBlock = ResultBlock


### PR DESCRIPTION
Without this change I always get the latest block 

The go parameter is indeed [_heightPtr_](https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/blocks.go#L230) but the query parameter is [_height_](https://github.com/tendermint/tendermint/blob/v0.32.2/rpc/core/blocks.go#L129). I'm not sure where and why the _Ptr_ bit gets removed, maybe because its type is a pointer?


The tests don't detect this because there's only one check and for the latest block
https://github.com/f-o-a-m/kepler/blob/bf75483fdc475eca3448eaf88489449167cdba21/hs-tendermint-client/kv-test/KVStore/Test/KVSpec.hs#L44-L47

Maybe there should be a few cases checking that the returned `blockMeta -> header -> height` matches the given height if below latest?